### PR TITLE
Own the NamedTuple conversion, closing D9

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -95,7 +95,8 @@ too much.
 
 ## 4. Defects on record
 
-D1 and D2 are fixed. The rest are noted so they are not lost; the phase column says where each belongs.
+D1, D2 and D9 are fixed. The rest are noted so they are not lost; the phase column says where each
+belongs.
 
 | # | defect | location | phase |
 |---|---|---|---|
@@ -107,14 +108,15 @@ D1 and D2 are fixed. The rest are noted so they are not lost; the phase column s
 | D6 | `ParameterHandling.flatten` defaults to `Float64`, silently promoting `Float32` networks | `GO/…/named_tuple_wrapper.jl:12-14` | **1 by design**; 3 |
 | D7 | With the type moved out of ANN, `ZygoteRules.pullback(f::Function, ::NeuralNetworkParameters)` owns neither argument type and becomes piracy there | `ANN/src/pullback_for_applychain.jl:10-17` | **1 provides the new home**; 2 |
 | D8 | Introduced by the separation: GML's `h5save(::H5DataStore, ::StiefelManifold, ::AbstractString)` and `changebackend(::NeuralNetworkBackend, ::StiefelManifold)` are now genuine type piracy — the generics are ANN's and the types are GO's, so GML owns nothing in either signature | `GML/ext/HDF5Ext.jl:17-50, 59-77` | 3 |
-| D9 | `Base.NamedTuple(p::NeuralNetworkParameters)` — Base's constructor and ANN's type, so the package defining it owns neither. Surfaced by GML [#207](https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/207), which needed it to write a nested parameter set to HDF5 | `GML/src/layers/forcing_dissipation_layers.jl` | **1 provides the home**; 2 |
+| D9 | `Base.NamedTuple(p::NeuralNetworkParameters)` — Base's constructor and ANN's type, so the package defining it owns neither. Surfaced by GML [#207](https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/207), which needed it to write a nested parameter set to HDF5 | `GML/src/layers/forcing_dissipation_layers.jl` | **1, fixed** |
 | D10 | `h5save(::HDF5.Group, ::NeuralNetworkParameters, ::AbstractString)` — ANN's generic and ANN's type, from GML. ANN's own extension has `h5save(::H5DataStore, ::NamedTuple, …)` and `save(::H5DataStore, ::NeuralNetworkParameters)`, but nothing for a parameter set nested at a path, which the parameter-dependent architectures produce. Also GML [#207](https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/207) | `GML/ext/HDF5Ext.jl` | 2 |
 
-D9 is one line of Phase 1 work that is not there yet: `src/parameters.jl` forwards `keys`, `values`,
-`getindex` and `pairs`, and has `params`, but no `Base.NamedTuple(p::NetworkParameters) = params(p)`.
-Adding it makes the conversion something this package owns, and Phase 2 makes it reachable from the
-`NeuralNetworkParameters` alias. D10 is the same shape one level up: with `src/io.jl` owning the
-generic HDF5 path, a nested parameter set serialises without anybody committing piracy.
+D9 was the one line of Phase 1 work that was missing, and `src/parameters.jl` now has it:
+`Base.NamedTuple(p::NetworkParameters) = params(p)`, next to the `keys`, `values`, `getindex` and
+`pairs` it already forwarded. The conversion is now something this package owns, and Phase 2 makes it
+reachable from the `NeuralNetworkParameters` alias. D10 is the same shape one level up: with
+`src/io.jl` owning the generic HDF5 path, a nested parameter set serialises without anybody
+committing piracy.
 
 D8 is the sharpest argument for the protocol. With the structured types upstream of the package that
 trains with them, a *generic* HDF5 path driven by `freeparameters`/`rebuild` is the only way to

--- a/docs/src/representations.md
+++ b/docs/src/representations.md
@@ -12,7 +12,10 @@ params
 ```
 
 `NetworkParameters` wraps a `NamedTuple` and forwards `getproperty`, `getindex`, `keys`, `values`,
-`length`, `iterate` and `pairs` to it, so it reads like the `NamedTuple` it holds.
+`length`, `iterate` and `pairs` to it, so it reads like the `NamedTuple` it holds. `NamedTuple(ps)`
+unwraps it again, and is the same thing as [`params`](@ref); the conversion is defined here rather
+than downstream because a package that owns neither `Base.NamedTuple` nor the type cannot define it
+without committing piracy on both counts.
 
 The wrapper is not decoration. A bare `NamedTuple` belongs to `Base`, so any package wanting to give a
 parameter set its own behaviour — saving it, flattening it, stepping an optimizer over it — must write

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -72,6 +72,12 @@ Base.length(p::NetworkParameters) = length(params(p))
 Base.iterate(p::NetworkParameters, args...) = iterate(params(p), args...)
 Base.pairs(p::NetworkParameters) = pairs(params(p))
 
+# The conversion belongs to this package, since it owns the type. Defining it downstream would be
+# piracy on both counts — `Base`'s constructor and this package's type — which is what
+# GeometricMachineLearning [#207](https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/207)
+# had to do to write a nested parameter set to HDF5.
+Base.NamedTuple(p::NetworkParameters) = params(p)
+
 Base.isequal(p1::NetworkParameters, p2::NetworkParameters) = isequal(params(p1), params(p2))
 Base.:(==)(p1::NetworkParameters, p2::NetworkParameters) = (params(p1) == params(p2))
 

--- a/test/parameters_tests.jl
+++ b/test/parameters_tests.jl
@@ -35,6 +35,13 @@ end
           NetworkParameters((b = [2.0], a = [1.0]))
 end
 
+@testset "conversion to a NamedTuple" begin
+    @test NamedTuple(ps) === nt
+    @test NamedTuple(ps) === params(ps)
+    # the round trip both ways, since this is what a downstream serialiser uses
+    @test NetworkParameters(NamedTuple(ps)) == ps
+end
+
 @testset "iteration" begin
     @test collect(ps) == collect(nt)
 end


### PR DESCRIPTION
`PLAN.md` §4 listed D9 as "one line of Phase 1 work that is not there yet":
`src/parameters.jl` forwarded `keys`, `values`, `getindex` and `pairs`, and had
`params`, but no `Base.NamedTuple(p::NetworkParameters)`.

Without it, a downstream that needs to turn a parameter set back into a plain
`NamedTuple` has to define the method itself — and owns neither `Base`'s
constructor nor the type, so the method is piracy on both counts. That is exactly
what [GeometricMachineLearning #207](https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/207)
had to do (`GML/src/layers/forcing_dissipation_layers.jl`) to write a nested
parameter set to HDF5.

## Changes

- `src/parameters.jl`: `Base.NamedTuple(p::NetworkParameters) = params(p)`.
- `test/parameters_tests.jl`: a testset covering the conversion, that it agrees
  with `params`, and the round trip back through `NetworkParameters`.
- `docs/src/representations.md`: mention the conversion where the other forwarded
  methods are listed, with the reason it lives here.
- `PLAN.md`: D9 moves to "1, fixed".

## Verification

```
julia --project -e 'using Pkg; Pkg.test()'    # 230 tests, was 226
julia --project=docs -e 'using Pkg; Pkg.develop(path="."); include("docs/make.jl")'
```

Both clean. This PR is independent of the rest of Phase 2 and can go in on its own;
Phase 2 in `AbstractNeuralNetworks` is what makes the conversion reachable through
the `NeuralNetworkParameters` alias.