### PR TITLE
Write the across-children walks out instead of retyping the tuple

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,7 @@ jobs:
             matrix:
                 version:
                     - "1.11"
+                    - "1.12"
                     - "^1.13.0-0"
                 os:
                     - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
             fail-fast: false
             matrix:
                 version:
-                    - "1.10"
+                    - "1.11"
                     - "^1.13.0-0"
                 os:
                     - ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,110 @@ Notable changes to `NeuralNetworkParameters` are recorded here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The package follows
 [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] — 2026-08-25
+
+**A branch with many children is usable.** 0.2.1 finished making the walks type stable and allocation
+free; this release makes them *compilable* on a branch wider than a couple of dozen children, which
+they were not.
+
+### Fixed
+
+- **Every walk across the children of one branch cost one specialisation per child.** The walk *down*
+  the tree is ordinary dispatch and was never the problem. The walk *across* was an `@inline`d
+  `Base.tail` chain, and `Base.tail` yields a new tuple type at every level — so a branch of `k`
+  children produced `k` specialisations whose argument types were each `O(k)` long, and inference on
+  that grew as `k³`.
+
+  Nine walks were written this way and all nine are now written out instead, as a `@generated` flat
+  body of `k` statements reading `getfield(xs, 1) … getfield(xs, k)` at *literal* indices: one
+  specialisation per branch shape rather than `k`, no new tuple types at all, every index inferred at a
+  constant, and the same straight-line code the chain used to inline down to. They are
+  `_flatten_children!`, `_unflatten_children`, `_unflatten_children!` (`src/flatten.jl`), `_map_zip`,
+  `_foreach_zip`, `_fold_children`, `_anynothing` (`src/walk.jl`), `_promote_eltypes`
+  (`src/leaves.jl`) and `_layout_children` (`src/layout.jl`).
+
+  First-call time, which is compilation plus a negligible run, on a flat `NamedTuple` of `k` leaves
+  (Julia 1.13, `scripts/wide_branch_cost.jl`):
+
+  | children | `flatten`, 0.2.1 | `flatten`, 0.2.2 | `mapparameters(zero, ·)` cold, 0.2.1 | 0.2.2 |
+  |---|---|---|---|---|
+  | 32 | 0.17 s | 0.09 s | 0.07 s | 0.00 s |
+  | 64 | 2.16 s | 0.23 s | 1.32 s | 0.00 s |
+  | 128 | 17.57 s | **0.56 s** | 7.39 s | 0.00 s |
+  | 369 | not run to completion | **2.05 s** | not run to completion | 0.00 s |
+
+  `map(zero, ·)` is unchanged throughout at 0.01 s, and is in the harness as the floor: it is what
+  `Base` costs on the same branch, and what a consumer that wrote its own walk over `map` to get around
+  this was paying instead.
+
+  369 is the width that made this worth fixing rather than noting: it is the parameter set of the MNIST
+  transformer in `scripts/geometric_optimizers/mnist.jl` of
+  [GMLDatasets.jl](https://github.com/JuliaGNI/GMLDatasets.jl) — 3·7·16 attention projections, 2·16
+  ResNet parameters and one classification weight, in one flat `NamedTuple` — written against this
+  package alone. `flatten` is on the path of every `GeometricOptimizers.GradientAutodiff`, so that
+  network could not be optimized through this package at all.
+
+  Two answers that look obvious are both wrong, and the harness above is what says so. **Dropping the
+  `@inline`** leaves the `k` specialisations exactly where they were: the same 64-child set went from
+  2.16 s to 3.22 s, *and* began allocating, because the inlining is what had kept the per-leaf
+  `copyto!` statically dispatched. **A `for` loop over the children**, which is what `Base.map` falls
+  back to past 32 fields, indexes a heterogeneous tuple at a runtime `i` — type-unstable, so a dynamic
+  dispatch and a boxed allocation per child, and the end of the property 0.2.1 exists to provide.
+
+  Reported from the review of [GeometricOptimizers#68], which hit this when widening its elementwise
+  primitives to a parameter container and had to write its own `map`-based walk to get around it.
+
+- **`flatten!` and `unflatten!` allocated on a branch of more than about forty children**, against the
+  guarantee in their own docstrings. Two temporary tuples were materialised per branch — `values(ps)`
+  and `values(l.children)` — which is free while a branch is narrow enough to keep in registers and is
+  not beyond that. Measured on the same flat sets, bytes per call from inside a function:
+
+  | children | 32 | 48 | 64 | 128 | 369 |
+  |---|---|---|---|---|---|
+  | 0.2.1 | 0 | 81 488 | 187 808 | not reached | not reached |
+  | 0.2.2 | 0 | **0** | **0** | **0** | **0** |
+
+  The walks index the branch in place with `getfield` now and take no `values` at all, so nothing is
+  materialised on the way in. This was found while fixing the entry above and is a separate defect:
+  narrowing the branch made it disappear, which is why the docstrings' claim had held up in testing.
+
+- **The reverse pass had the same two defects**, on the walk that turns a cotangent in the shape of the
+  parameters back into a flat gradient. `_accumulate_named!` was a `Base.tail` chain over
+  `values(l.children)` and `keys(l.children)`; it is written out now, with the branch's keys spliced in
+  as *literal* `Symbol`s — which is what keeps `_cotangent_get`'s `haskey` a compile-time question, the
+  property the chain had been relying on constant propagation for. `_matching_named` goes with it.
+
+  Bytes per pullback call, on the same flat sets:
+
+  | children | 16 | 32 | 48 | 64 | 128 | 369 |
+  |---|---|---|---|---|---|---|
+  | 0.2.1 | 320 | 576 | 70 592 | 161 504 | not reached | not reached |
+  | 0.2.2 | 320 | 576 | **848** | **1 120** | **2 112** | **6 208** |
+
+  Identical up to 32 children and 144× better at 64, which is the signature of the same cliff: below it
+  the temporary tuples stay in registers, above it they do not.
+
+  The two *positional* walks — `_accumulate_positional!` and `_matching_positional` — are deliberately
+  left as chains, and the comment beside them now says why: their length is the number of blocks of a
+  single leaf, two for a `StiefelLieAlgHorMatrix` and one for a Grassmann lift, so they are never wide
+  the way a branch of layers is.
+
+### Added
+
+- `test/wide_branch_tests.jl`, which walks a 369-child branch through `flatten`/`unflatten`,
+  `mapparameters` at both arities, `mapparameters!`, `foreachparameters` with and without the `nothing`
+  skip, `foldparameters` and `parameter_eltype`, and pins the in-place forms at zero allocations there.
+  It also covers 48, either side of the 32 fields `Base` unrolls a tuple up to.
+
+  It asserts the properties and not the timings — a wall-clock bound would be a flake on a loaded
+  machine — so the regression test is that the file *completes*, which before this release it did not.
+  It costs the suite about 40 s, all of it compilation at the wide width, and that is the honest price
+  of covering the width a consumer actually has.
+
+- `scripts/wide_branch_cost.jl`, the harness behind both tables above.
+
+[GeometricOptimizers#68]: https://github.com/JuliaGNI/GeometricOptimizers.jl/pull/68
+
 ## [0.2.1] — 2026-08-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,44 +35,95 @@ they were not.
   children produced `k` specialisations whose argument types were each `O(k)` long, and inference on
   that grew as `k³`.
 
-  Nine walks were written this way and all nine are now written out instead, as a `@generated` flat
-  body of `k` statements reading `getfield(xs, 1) … getfield(xs, k)` at *literal* indices: one
-  specialisation per branch shape rather than `k`, no new tuple types at all, every index inferred at a
-  constant, and the same straight-line code the chain used to inline down to. They are
-  `_flatten_children!`, `_unflatten_children`, `_unflatten_children!` (`src/flatten.jl`), `_map_zip`,
-  `_foreach_zip`, `_fold_children`, `_anynothing` (`src/walk.jl`), `_promote_eltypes`
-  (`src/leaves.jl`) and `_layout_children` (`src/layout.jl`).
+  Nine walks were written this way. Eight are written out instead, as a `@generated` flat body of `k`
+  statements reading `getfield(xs, 1) … getfield(xs, k)` at *literal* indices: one specialisation per
+  branch shape rather than `k`, no new tuple types at all, every index inferred at a constant, and the
+  same straight-line code the chain used to inline down to. They are `_flatten_children!`,
+  `_unflatten_children`, `_unflatten_children!` (`src/flatten.jl`), `_foreach_zip`, `_fold_children`,
+  `_anynothing` (`src/walk.jl`), `_promote_eltypes` (`src/leaves.jl`) and the two branch cases of
+  `_layout` (`src/layout.jl`).
 
-  First-call time, which is compilation plus a negligible run, on a flat `NamedTuple` of `k` leaves
-  (Julia 1.13, `scripts/wide_branch_cost.jl`):
+  The ninth, `_map_zip`, is written out **to 32 children and hands wider branches to `Base.map`**, and
+  the asymmetry is the point rather than an exception. Writing a body out costs compilation per branch
+  shape; `map` costs type stability past 32 fields, where `Base` drops to its `Any32` loop. Which of
+  those is the bad trade depends entirely on whether the walk runs in an inner loop. The eight above
+  do — `flatten!` and `unflatten!` once per optimizer iteration, `_unflatten_children` once per
+  objective evaluation through the closure a `Gradient` is built from — and there a dynamic dispatch
+  per child would be paid on every call. `_map_zip` is what `mapparameters` and `mapstorage` are, and a
+  consumer calls those once per cache, once per `changebackend`, once per `map_to_cpu`; there the same
+  dispatch is paid once, and the object handed back is concretely typed either way, so everything
+  downstream of it specialises normally.
 
-  | children | `flatten`, 0.2.1 | `flatten`, 0.2.2 | `mapparameters(zero, ·)` cold, 0.2.1 | 0.2.2 |
-  |---|---|---|---|---|
-  | 32 | 0.17 s | 0.09 s | 0.07 s | 0.00 s |
-  | 64 | 2.16 s | 0.23 s | 1.32 s | 0.00 s |
-  | 128 | 17.57 s | **0.56 s** | 7.39 s | 0.00 s |
-  | 369 | not run to completion | **2.05 s** | not run to completion | 0.00 s |
+  What that is worth: `GeometricOptimizers` reaches six such primitives while building one
+  `OptimizerCache`, and on the 369-entry flat set that took **1.57 s on its 0.5.0 to 71.16 s** with
+  `_map_zip` written out at every width, against **2.41 s** with the split. See the note on `_map_zip`
+  in `src/walk.jl`, which carries the measurement.
 
-  `map(zero, ·)` is unchanged throughout at 0.01 s, and is in the harness as the floor: it is what
-  `Base` costs on the same branch, and what a consumer that wrote its own walk over `map` to get around
-  this was paying instead.
+  First-call time, which is compilation plus a negligible run, on a flat `NamedTuple` of `k` leaves.
+  **Every figure below is cold**: `scripts/wide_branch_cost.jl` runs each width in a process of its own,
+  and the 0.2.1 column comes from running that same script against a worktree of `v0.2.1`, so the two
+  are comparable rather than merely recorded. Julia 1.11.9, Apple M4 Max.
 
-  369 is the width that made this worth fixing rather than noting: it is the parameter set of the MNIST
-  transformer in `scripts/geometric_optimizers/mnist.jl` of
-  [GMLDatasets.jl](https://github.com/JuliaGNI/GMLDatasets.jl) — 3·7·16 attention projections, 2·16
-  ResNet parameters and one classification weight, in one flat `NamedTuple` — written against this
-  package alone. `flatten` is on the path of every `GeometricOptimizers.GradientAutodiff`, so that
-  network could not be optimized through this package at all.
+  Within one width the rows are *cumulative* — `parameterlayout` runs first and `flatten` builds a
+  layout too, so each row is what it adds to the ones above it. The total is what a consumer pays to
+  compile the whole path, and is the column to read:
 
-  Two answers that look obvious are both wrong, and the harness above is what says so. **Dropping the
-  `@inline`** leaves the `k` specialisations exactly where they were: the same 64-child set went from
-  2.16 s to 3.22 s, *and* began allocating, because the inlining is what had kept the per-leaf
-  `copyto!` statically dispatched. **A `for` loop over the children**, which is what `Base.map` falls
-  back to past 32 fields, indexes a heterogeneous tuple at a runtime `i` — type-unstable, so a dynamic
-  dispatch and a boxed allocation per child, and the end of the property 0.2.1 exists to provide.
+  | children | `parameterlayout` | `mapparameters` | `flatten` | `unflatten` | **total** |
+  |---|---|---|---|---|---|
+  | 16 | 0.05 → 0.07 | 0.05 → 0.05 | 0.09 → 0.09 | 0.15 → 0.12 | 0.40 → **0.40** |
+  | 32 | 0.12 → 0.08 | 0.13 → 0.12 | 0.25 → 0.18 | 0.46 → 0.26 | 0.97 → **0.65** |
+  | 48 | 0.19 → 0.15 | 0.22 → 0.04 | 0.37 → 0.30 | 0.66 → 0.39 | 1.45 → **0.89** |
+  | 64 | 0.29 → 0.21 | 0.43 → 0.04 | 0.62 → 0.43 | 1.12 → 0.53 | 2.47 → **1.22** |
+  | 128 | 1.85 → 0.65 | 1.43 → 0.05 | 2.08 → 2.25 | 3.63 → 1.14 | 9.00 → **4.10** |
+  | 369 | 12.32 → 1.35 | 8.56 → 0.09 | 12.82 → 14.39 | 22.32 → 4.38 | 56.03 → **20.22** |
 
-  Reported from the review of [GeometricOptimizers#68], which hit this when widening its elementwise
-  primitives to a parameter container and had to write its own `map`-based walk to get around it.
+  `map(zero, ·)` is 0.01 s at every width on both and is omitted; it is in the harness as the floor —
+  what `Base` costs on the same branch, and what a consumer that wrote its own walk over `map` to get
+  around this was paying instead.
+
+  The `flatten` column is the one that goes the wrong way at the two largest widths, and it is a
+  re-attribution rather than a loss: `parameterlayout` no longer absorbs the shared compilation, so
+  `flatten` pays for it instead. Measured alone in its own process at 369 children, `flatten` is
+  13.78 s on 0.2.1 and 16.29 s here — a real 18 % — against 12.32 s and 1.36 s for `parameterlayout`.
+  That trade is taken deliberately; see the leaf-dispatch entry below for why the instability it
+  removes is worth more than the 18 %.
+
+  **An earlier draft of this entry quoted different figures**, and they are worth naming because of how
+  they were wrong rather than by how much. It had `flatten` at 17.57 s on 0.2.1 at 128 children and
+  "not run to completion" at 369 — where cold it is 2.08 s and 12.82 s, and completes. The *conclusion*
+  was right, and not one of the numbers supporting it was: the harness swept the widths in a single
+  process, so every row after the first was measuring what its predecessors had already compiled. The
+  `mapparameters` column suffered worst, reading as `0.00 s` what costs 0.09 s cold — and 1.51 s cold
+  before the `_map_zip` split above. `GeometricOptimizers` closed an issue of its own on that `0.00 s`.
+
+  The script forks per width now, so there is no ordering left to get wrong and no `--cold-map` flag to
+  remember: a figure is cold or it is not printed. That is the general lesson and it is cheap to state —
+  **a measurement you have to ask for in a special way is one the default run is getting wrong.**
+
+- **`_layout` on a leaf inferred as a three-way union, and a branch of 369 of them was what
+  `parameterlayout` cost.** The leaf method asked `freeparameters(x) === x` in an `if`, and that is a
+  runtime pointer comparison inference cannot fold — so `_layout(::Matrix{Float32}, ::Int)` came back
+  as `Union{Tuple{LeafLayout{2,Matrix{Float32}},Int}, Tuple{WrappedLayout{…},Int}, Tuple{WrappedLayout{…} where …,Int}}`.
+  One union per child is survivable; 369 of them is 11.7 s of inference.
+
+  Terminality is decided by **dispatch** now — `_layout_storage(x::T, ::T, offset)` against the general
+  method — and the branch construction is fused into the same `@generated` body that lays the children
+  out, rather than returning a `k`-element tuple for a caller to infer through. `parameterlayout` on
+  that set is **1.36 s**, and 25.2 s → 15.35 s on a 16 × 24 nested container.
+
+  Three other explanations were measured and ruled out first, which is why they are recorded: a
+  `@noinline` barrier on the child walk (11.78 s, no change), supplying `NestedLayout`'s type
+  parameters rather than letting them be solved (no change), and computing the child lengths first so
+  the children could be laid out *independently* — **worse**, 15.4 s, because it adds two more `k`-long
+  bodies. The serial offset dependency was never the cost: an "every child at the same offset" control
+  runs at 1.17 s against the real walk's 1.27 s.
+
+  One semantic edge changes with it. A leaf whose `freeparameters` returns a *distinct object of its
+  own type* is now treated as terminal where the `===` would have wrapped it. Nothing is lost: such a
+  type never worked, since `_layout` would descend into the storage, ask it for its own
+  `freeparameters`, and recurse without end unless it eventually changed type. [`isterminal`](@ref)
+  still asks the identity question and is still right to — it is a predicate a caller evaluates on a
+  value it holds, not a dispatch anything has to infer through.
 
 - **`flatten!` and `unflatten!` allocated on a branch of more than about forty children**, against the
   guarantee in their own docstrings. Two temporary tuples were materialised per branch — `values(ps)`
@@ -80,10 +131,14 @@ they were not.
   not beyond that. Measured on the same flat sets on Julia 1.13, bytes per call from inside a
   function:
 
-  | children | 32 | 48 | 64 | 128 | 369 |
-  |---|---|---|---|---|---|
-  | 0.2.1 | 0 | 81 488 | 187 808 | not reached | not reached |
-  | 0.2.2 | 0 | **0** | **0** | **0** | **0** |
+  | children | 16 | 32 | 48 | 64 | 128 | 369 |
+  |---|---|---|---|---|---|---|
+  | 0.2.1 | 0 | 0 | 70 288 | 160 928 | 770 624 | 6 608 576 |
+  | 0.2.2 | 0 | 0 | **0** | **0** | **0** | **0** |
+
+  Re-measured cold with the rest, which moved the 0.2.1 row: an earlier draft had 81 488 at 48 children
+  and 187 808 at 64, and "not reached" beyond, where the per-width harness reaches every one of them.
+  Same shape, same cliff, different numbers.
 
   The walks index the branch in place with `getfield` now and take no `values` at all, so nothing is
   materialised on the way in. This was found while fixing the entry above and is a separate defect:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ Notable changes to `NeuralNetworkParameters` are recorded here, following
 free; this release makes them *compilable* on a branch wider than a couple of dozen children, which
 they were not.
 
+### Changed
+
+- **Julia 1.11 is now the minimum**, up from 1.10. The walks below are `@generated` bodies, and Julia
+  1.10 cannot inline one: neither `Expr(:meta, :inline)` in the generated body, nor `@inline` on the
+  declaration, nor `@inline` at the call site has any effect there — the call stays out of line. The
+  bodies are allocation-free on 1.10 too; what `flatten!` and `unflatten!` need from the inlining is
+  that it lets the temporaries at a branch boundary be elided. Without it, on 1.10, against 0.2.1:
+
+  | set | `flatten!` | `unflatten!` | `unflatten` |
+  |---|---|---|---|
+  | one with structured leaves | 0 → 192 | 0 → 608 | 576 → 1616 |
+  | a two-level `NamedTuple` | 0 → 0 | 0 → 176 | 960 → 1408 |
+
+  That is the guarantee 0.2.1 exists to provide, so on 1.10 the two cannot both be had. Julia 1.11 and
+  later elide those temporaries without inlining, and 1.11, 1.12 and 1.13 were each checked at zero on
+  a nested set, a set with structured leaves, a wide flat branch and a wide branch of branches.
+
 ### Fixed
 
 - **Every walk across the children of one branch cost one specialisation per child.** The walk *down*
@@ -60,7 +77,8 @@ they were not.
 - **`flatten!` and `unflatten!` allocated on a branch of more than about forty children**, against the
   guarantee in their own docstrings. Two temporary tuples were materialised per branch — `values(ps)`
   and `values(l.children)` — which is free while a branch is narrow enough to keep in registers and is
-  not beyond that. Measured on the same flat sets, bytes per call from inside a function:
+  not beyond that. Measured on the same flat sets on Julia 1.13, bytes per call from inside a
+  function:
 
   | children | 32 | 48 | 64 | 128 | 369 |
   |---|---|---|---|---|---|
@@ -77,7 +95,7 @@ they were not.
   as *literal* `Symbol`s — which is what keeps `_cotangent_get`'s `haskey` a compile-time question, the
   property the chain had been relying on constant propagation for. `_matching_named` goes with it.
 
-  Bytes per pullback call, on the same flat sets:
+  Bytes per pullback call, on the same flat sets and again on Julia 1.13:
 
   | children | 16 | 32 | 48 | 64 | 128 | 369 |
   |---|---|---|---|---|---|---|
@@ -113,10 +131,15 @@ they were not.
   skip, `foldparameters` and `parameter_eltype`, and pins the in-place forms at zero allocations there.
   It also covers 48, either side of the 32 fields `Base` unrolls a tuple up to.
 
+  A 48-wide branch whose children are themselves branches is covered as well, and separately, because
+  the two shapes fail differently: a flat branch's children are arrays, which are heap objects
+  already, so a walk that reaches one has nothing to keep off the heap, while a branch of branches has
+  to be taken apart in place at every level. The width is a consumer's; the nesting is a network's.
+
   It asserts the properties and not the timings — a wall-clock bound would be a flake on a loaded
   machine — so the regression test is that the file *completes*, which before this release it did not.
-  It costs the suite about 40 s, all of it compilation at the wide width, and that is the honest price
-  of covering the width a consumer actually has.
+  It costs the suite about 45 s on Julia 1.13 and about 1 m 45 s on 1.11, all of it compilation at the
+  wide width, and that is the honest price of covering the width a consumer actually has.
 
 - `scripts/wide_branch_cost.jl`, the harness behind both tables above.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,11 @@ they were not.
   | 48 | 0.58 → 0.20 | 1.09 → 0.10 | 1.31 → 0.23 | 1.26 → 0.46 | 4.24 → **0.99** |
   | 64 | 1.32 → 0.22 | 2.63 → 0.10 | 3.15 → 0.32 | 2.95 → 0.72 | 10.05 → **1.36** |
   | 128 | 7.75 → 0.51 | 24.49 → 0.12 | 27.84 → 0.70 | 25.82 → 2.01 | 85.90 → **3.34** |
-  | 369 | not reached → 1.73 | → 0.17 | → 2.48 | → 19.27 | not reached → **24.65** |
+  | 369 | — → 1.73 | — → 0.17 | — → 2.48 | — → 19.27 | — → **24.65** |
+
+  The 369-child row has no 0.2.1 column: `parameterlayout` alone was still compiling after 20 minutes
+  in a process of its own, which is the "did not finish" of the original report, now with a lower bound
+  on it. Every other row is a completed measurement of both trees.
 
   The shape is the same as the 1.11.9 table above and the margin is wider, because the figures the old
   harness printed were missing the inference that is most of the cost. 16 children is the one width
@@ -179,7 +183,7 @@ they were not.
 
   | children | 16 | 32 | 48 | 64 | 128 | 369 |
   |---|---|---|---|---|---|---|
-  | 0.2.1 | 0 | 0 | 23 488 | 54 848 | 265 408 | not reached |
+  | 0.2.1 | 0 | 0 | 23 488 | 54 848 | 265 408 | — |
   | first written here | 0 | 0 | 800 | 1 088 | 2 176 | 6 144 |
   | **now** | 0 | 0 | **0** | **0** | **0** | **0** |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,20 @@ they were not.
 
 ### Added
 
+- **`ParameterSet`**, exported: `Union{NetworkParameters, NamedTuple}`, the type to dispatch on when a
+  method takes *the parameters* and does not care which of the two forms it was handed.
+
+  Every package in this ecosystem was spelling that union out inline — `AbstractNeuralNetworks` at
+  eight sites, `GeometricMachineLearning` at fifteen, `GeometricOptimizers` at sixteen — and
+  `SymbolicNeuralNetworks` had named it `EquationSet` for the equation sets that share the shape. One
+  name means a reader meets the same type in all of them.
+
+  Its docstring states the two things it is not. It is **not** `isparametertree`, which is also true of
+  a `Tuple`, because a `Tuple` is a branch the walks recurse into — what `freeparameters` returns for a
+  multi-block leaf — and never a set of parameters handed in whole. And it puts no bound on the element
+  type or the depth, so it is **not** `GeometricOptimizers.ParameterContainer{T}`, which additionally
+  requires the `NamedTuple` half to be flat and element-type-homogeneous.
+
 - `test/wide_branch_tests.jl`, which walks a 369-child branch through `flatten`/`unflatten`,
   `mapparameters` at both arities, `mapparameters!`, `foreachparameters` with and without the `nothing`
   skip, `foldparameters` and `parameter_eltype`, and pins the in-place forms at zero allocations there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,32 @@ they were not.
   remember: a figure is cold or it is not printed. That is the general lesson and it is cheap to state —
   **a measurement you have to ask for in a special way is one the default run is getting wrong.**
 
+  Re-measured with the corrected harness — see the entry below on `first_call` — on Julia 1.13.0-rc2,
+  Apple M4 Max, one process per width, seconds, `0.2.1 → 0.2.2`:
+
+  | children | `parameterlayout` | `mapparameters` | `flatten` | `unflatten` | **total** |
+  |---|---|---|---|---|---|
+  | 16 | 0.04 → 0.10 | 0.08 → 0.15 | 0.09 → 0.11 | 0.12 → 0.10 | 0.33 → **0.46** |
+  | 32 | 0.08 → 0.13 | 0.22 → 0.26 | 0.22 → 0.16 | 0.35 → 0.25 | 0.87 → **0.80** |
+  | 48 | 0.58 → 0.20 | 1.09 → 0.10 | 1.31 → 0.23 | 1.26 → 0.46 | 4.24 → **0.99** |
+  | 64 | 1.32 → 0.22 | 2.63 → 0.10 | 3.15 → 0.32 | 2.95 → 0.72 | 10.05 → **1.36** |
+  | 128 | 7.75 → 0.51 | 24.49 → 0.12 | 27.84 → 0.70 | 25.82 → 2.01 | 85.90 → **3.34** |
+  | 369 | not reached → 1.73 | → 0.17 | → 2.48 | → 19.27 | not reached → **24.65** |
+
+  The shape is the same as the 1.11.9 table above and the margin is wider, because the figures the old
+  harness printed were missing the inference that is most of the cost. 16 children is the one width
+  where 0.2.2 is behind, by 0.13 s, which is a written-out body being compiled where a chain of four
+  was not — the trade the `_map_zip` note describes, at the width where it does not pay.
+
+  **The harness had a second way of not measuring the thing, and forking per width did not touch it.**
+  `first_call` timed a direct `f(args...)`, and compiling `first_call` itself infers through the call in
+  its body — so the inference the figure is *for* was spent while `first_call` was being compiled, before
+  its own `t = time()` ran. On Julia 1.13 that reads **0.00 s for every width in every column**;
+  `parameterlayout` on a 369-child branch, measured through an opaque call, is 1.61 s and `flatten` is
+  3.95 s. The call goes through `Base.invokelatest` now, so there is nothing left for the caller's
+  compilation to do first. Same lesson as the fork, from the other end: the harness has to be arranged so
+  that the cost cannot have been paid somewhere the clock is not looking.
+
 - **`_layout` on a leaf inferred as a three-way union, and a branch of 369 of them was what
   `parameterlayout` cost.** The leaf method asked `freeparameters(x) === x` in an `if`, and that is a
   runtime pointer comparison inference cannot fold — so `_layout(::Matrix{Float32}, ::Int)` came back
@@ -144,6 +170,67 @@ they were not.
   materialised on the way in. This was found while fixing the entry above and is a separate defect:
   narrowing the branch made it disappear, which is why the docstrings' claim had held up in testing.
 
+- **`mapparameters!`, `mapstorage!` and `foreachparameters` had the same defect, on the arm that takes a
+  second set** — and they are the walks that run every optimizer iteration, where `flatten!` runs once
+  or twice. The entry above removed the temporary from the branch being walked; each *further* argument
+  was still turned into a `values(...)` tuple per branch by `_values_for`, and a skipped set into a
+  fresh `map(_ -> nothing, keys)` tuple on top of that. Bytes per call of `mapparameters!(f, dest, src)`
+  on Julia 1.13:
+
+  | children | 16 | 32 | 48 | 64 | 128 | 369 |
+  |---|---|---|---|---|---|---|
+  | 0.2.1 | 0 | 0 | 23 488 | 54 848 | 265 408 | not reached |
+  | first written here | 0 | 0 | 800 | 1 088 | 2 176 | 6 144 |
+  | **now** | 0 | 0 | **0** | **0** | **0** | **0** |
+
+  The middle row is the point rather than the top one: removing the temporary from the branch *being*
+  walked took 23 488 bytes at 48 children down to 800, which looks like the defect closing and is the
+  cliff simply moved. A branch of branches, where every child is a branch to take apart rather than an
+  array, cost 3 168 bytes at 48 and 23 840 at 369 on the middle row.
+
+  Same cliff at the same width, for the same reason. `_foreach_zip` reads every one of its arguments
+  with `getfield` at a literal index now; `_values_for` and `_tuple_for` have no callers and are gone.
+  Zero at 4, 16, 32, 48, 64, 128 and 369 children, flat and nested, at arity one, two and three, and on
+  the `nothing`-skip path.
+
+  Not caught by the wide-branch tests as first written, which did call `mapparameters!` at 369 children
+  and asserted only its result. Measuring it needs a **zero-argument closure**: `@allocated f(a, b)`
+  lowers to `Base.allocated(f, a, b)`, and for a `Vararg` method — which all three of these are — the
+  splat inside `Base.allocated` allocates on its own account, inventing bytes the walk does not spend
+  and hiding the ones it does. `test/wide_branch_tests.jl` says so beside the harness.
+
+- **The in-place walks paired the children of two branches by *position*.** `_values_for(x, ks)` ignored
+  its `ks`, so `foreachparameters(copyto!, (a = …, b = …), (b = …, a = …))` wrote each leaf from the
+  wrong key and said nothing, where `mapparameters` has always raised. Two same-shaped sets whose keys
+  are ordered differently — a gradient tree built by hand, or merged from parts — silently crossed over.
+
+  The generated body checks the keys of a named argument against the branch's own, in the *generator*,
+  so the guard `mapparameters` pays `_check_keys` for at run time is free here. **This is a behaviour
+  change**: positional pairing of differently-keyed sets now raises `ArgumentError`. A `Tuple` branch
+  stays positional, because the blocks of a multi-block leaf have no keys to agree on.
+
+- **`mapparameters` and `mapstorage` re-selected every child they were just handed.** Past 32 children
+  `_map_zip` hands back a `NamedTuple` already keyed with `keys(ps)`, and both then ran it through
+  `NamedTuple{keys(ps)}(...)` again — a second `k`-wide generated selection and a copy, 6 272 bytes of
+  the 57 120 a call costs at 369 children. `_rewrap_children` keys the written-out arm's `Tuple` and
+  leaves the `map` arm's `NamedTuple` alone.
+
+- **The reverse pass indexed leaf cotangents one element at a time.** `_add_leaf_cotangent!` accumulated
+  with `enumerate(Δ)` and a scalar `Δv[o + i] += x`, while `flatten`'s docstring makes a point of the
+  forward path never indexing an element, "so it runs at memory bandwidth and works unchanged for GPU
+  arrays". It broadcasts over the leaf's stretch of the flat vector now, at the same 848 and 6 208 bytes
+  at 48 and 369 children, and reaches a device array on the same terms the forward path does.
+
+- **The arity check allocated on `mapparameters`' own path.** `_children_arity` took an untyped `rest...`
+  and walked it with `enumerate`; every caller but one reaches it from a generator, where that is free,
+  and `_map_zip` reaches it at run time, where it cost 48 bytes a call. It takes the further sets as one
+  tuple now and checks them with a chain over the *arity* — one or two, never a branch width.
+
+- `_tuple_for(::Nothing, n::Int)` filled a positional branch with `ntuple(_ -> nothing, n)`, which
+  infers as `Tuple{Vararg{Nothing}}` past ten blocks — the same instability the comment in
+  `src/derivatives.jl` records removing from `_matching_positional`. The generated body splices the
+  `nothing`s in as literals, so there is no length left to be runtime about.
+
 - **The reverse pass had the same two defects**, on the walk that turns a cotangent in the shape of the
   parameters back into a flat gradient. `_accumulate_named!` was a `Base.tail` chain over
   `values(l.children)` and `keys(l.children)`; it is written out now, with the branch's keys spliced in
@@ -183,8 +270,10 @@ they were not.
 
 - `test/wide_branch_tests.jl`, which walks a 369-child branch through `flatten`/`unflatten`,
   `mapparameters` at both arities, `mapparameters!`, `foreachparameters` with and without the `nothing`
-  skip, `foldparameters` and `parameter_eltype`, and pins the in-place forms at zero allocations there.
-  It also covers 48, either side of the 32 fields `Base` unrolls a tuple up to.
+  skip, `foldparameters` and `parameter_eltype`, and pins **every** in-place form at zero allocations
+  there — `flatten!` and `unflatten!`, and `mapparameters!`, `mapstorage!` and `foreachparameters` at
+  arity one, two and three and on the `nothing`-skip path. It also covers 48, either side of the 32
+  fields `Base` unrolls a tuple up to.
 
   A 48-wide branch whose children are themselves branches is covered as well, and separately, because
   the two shapes fail differently: a flat branch's children are arrays, which are heap objects

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,18 +1,32 @@
 # NeuralNetworkParameters.jl — analysis and plan
 
-Analysis last revised 2026-08-26, against these working trees:
+Analysis last revised 2026-08-26, against these working trees. Every version in the table is a
+*branch*, not a release: the whole family moves in one wave and only this package's dependency,
+`ChainRulesCore`, is outside it.
 
-| package | version | commit |
+| package | version | branch |
 |---|---|---|
-| `NeuralNetworkParameters` | 0.2.2 | this repository |
-| `AbstractNeuralNetworks` | 0.7.1 | `c628a34` |
-| `SymbolicNeuralNetworks` | 0.7.0 | `c0a75e5` |
-| `GeometricMachineLearning` | 0.6.0 | `33a3ce6f` |
-| `GeometricOptimizers` | 0.5.0 | `4c9f443` (branch `preallocate-the-flat-buffers`) |
-| `NonlinearIntegrators` | 0.4.1 | `f8a6268` |
+| `NeuralNetworkParameters` | 0.2.2 | this repository, `fix-d9-wide-branch-compile-cost` |
+| `GeometricBase` | 0.14.9 | `l2norm-over-any-array-and-julia-1.11` |
+| `SimpleSolvers` | 0.13.1 | `retire-the-1.10-getrf-fallback` |
+| `AbstractNeuralNetworks` | 0.7.2 | `adopt-parameterset` |
+| `SymbolicNeuralNetworks` | 0.7.1 | `adopt-parameterset` |
+| `GeometricOptimizers` | 0.6.0 | `preallocate-the-flat-buffers` (on `widen-the-primitives-…`) |
+| `GeometricMachineLearning` | 0.6.1 | `adopt-parameterset` |
+| `NonlinearIntegrators` | 0.4.2 | `julia-1.11-and-geometricoptimizers-0.6` |
+| `GMLDatasets` | 0.1.0 | `repair-the-mnist-scripts-against-geometricoptimizers-0.5` |
 
 Paths written `ANN/…`, `SNN/…`, `GML/…`, `GO/…`, `NLI/…` are relative to the corresponding sibling
 checkout.
+
+**Julia 1.11 is the floor across all nine.** Every workaround the move retires was a *1.10*
+workaround, and they were in three places: `SimpleSolvers`' `HAS_PREALLOCATED_GETRF`, whose fallback
+allocated the pivot vector on every factorization in the default linear solver (3360 bytes at
+``n = 384``, measured on 1.10.11); `SymbolicNeuralNetworks`' `Base.tail` walk in `unflatten_batch`,
+which existed for a 1.10-only saving and had this package's D12 in exchange; and a set of 1.10-only
+allocation ceilings in `SNN` and `NLI`. Nothing wanted 1.12, and `GeometricOptimizers`' open issue D1
+is a 140× compile-time cliff *on* 1.12 that 1.13 does not have — so 1.12 would have been the wrong
+floor to choose. It stays in every CI matrix instead.
 
 **Status.** Phase 1 is released and registered in General. Phase 2 is complete: this package is where
 the parameter container lives, and `AbstractNeuralNetworks` consumes it. **Phase 3 is done** —
@@ -62,11 +76,19 @@ records what has actually come of it.
 each leaf, put it back: that is `flatten`/`unflatten`, `h5save`/`h5load`, `changebackend`, `map_to_cpu`,
 `_statify`, the optimizer's elementwise primitives, and `_eltype`/`apply_toNT` — each re-declaring a
 method per structured type, in four packages. Written once against the leaf protocol, one
-implementation covers all of them and needs to know none of the types. What that has come to: ANN's
-copies are gone, its `changebackend` and `_statify` each one `mapparameters` call; GML's `h5save` and
-its "natural sort" are gone; SNN's `FlatSlice` is gone. What is left is GML's `map_to_cpu`, its
-`apply_toNT`/`_eltype` and its step dispatcher, and GO's `apply_toNT` and its `ParameterHandling`
-flattening — §8 has both.
+implementation covers all of them and needs to know none of the types. **What that has come to, checked
+against the working trees rather than remembered:** ANN's copies are gone, its `changebackend` and
+`_statify` each one `mapparameters` call; GML's `h5save` and its "natural sort" are gone, its
+`map_to_cpu` is one `mapstorage` call, and its `apply_toNT` and `_eltype` are gone with them; SNN's
+`FlatSlice` is gone; GO's `apply_toNT` and its `ParameterHandling` flattening went in 0.5.0 and its
+`_mapleaves` in 0.6.0.
+
+**One is left, and it is left on purpose.** GML's `_tree_optim_step!` is still hand-written, and
+`GML/src/optimizers/optimizer.jl:270-292` now gives two reasons that `foreachparameters` cannot serve:
+the recursion is keyed on the *cache* tree and stops where the cache stops, so a layer's `NamedTuple`
+arrives whole rather than being descended into; and `λY` is *broadcast* rather than zipped, one
+`GlobalSection` standing in for a whole subtree. That is a different walk, not a copy of this one.
+Earlier revisions of this section listed four more items here that had already been done.
 
 **A parameter set needs to be a type somebody owns.** Most of the type piracy `GeometricOptimizers`
 issue #16 tracks is not about flattening: the container is a bare `NamedTuple` (aliased
@@ -128,9 +150,15 @@ checkouts, so §8 is now written as *where each package stands* rather than as a
 
 ## 4. Defects on record
 
-D1, D2, D4, D7, D9, D10, D12, D13, D14 and half of D8 are fixed. The rest are noted so they are not
-lost; the status column says where each stands. D11 is new since the 2026-08-19 revision — the piracy
-inventory grows as packages adopt the container ahead of the ones they depend on.
+D1, D2, D3, D4, D7, D8, D9, D10, D11, D12, D13 and D14 are fixed — which is all of them but D5 and
+D6, and those two are open *in `GeometricOptimizers`* rather than here. D15 and D16 are new in this
+revision and are both defects of this package's own 0.2.2 work, found by running it rather than by
+reading it.
+
+**Three entries in this table were stale when this revision began**, and all three in the same
+direction: D3, the `changebackend` half of D8, and D11 were recorded as open and had been fixed in
+`GeometricOptimizers` 0.5.0 and `GeometricMachineLearning` 0.6.0. §3's lesson had one revision of
+practice and then failed again.
 
 **D12, D13 and D14 are this package's own, and none of them was found here.** All three came from the
 review of `GeometricOptimizers` #68, which needed `mapparameters` on the one parameter shape it has a
@@ -144,18 +172,20 @@ has, and `scripts/wide_branch_cost.jl` is the harness.
 |---|---|---|---|
 | D1 | `Aversion = "0.1.0"` typo — the package had **no `version` field at all** | `Project.toml:4` | **fixed, phase 1** |
 | D2 | Stale `Manifest.toml` pinning `AbstractNeuralNetworks v0.3.0` | `Manifest.toml` | **fixed, phase 1** — the file is untracked and `.gitignore`d |
-| D3 | `changebackend` for the five wrapper types is defined **only inside GML's HDF5 extension**, so `changebackend(GPU(), nn)` on a `PSDLayer`/`LASympNet` network MethodErrors unless HDF5 happens to be loaded | `GML/ext/HDF5Ext.jl:23-41` | open — see the GML remainder in §8 |
+| D3 | `changebackend` for the five wrapper types is defined **only inside GML's HDF5 extension**, so `changebackend(GPU(), nn)` on a `PSDLayer`/`LASympNet` network MethodErrors unless HDF5 happens to be loaded | was `GML/ext/HDF5Ext.jl` | **fixed** — `GO/ext/AbstractNeuralNetworksExt.jl` carries one method over `Manifold`/`VectorStorageMatrix`/`AbstractLieAlgHorMatrix`, delegating to `mapstorage`, and GML's copies are gone. `changebackend(GPU(), nn)` no longer depends on HDF5 being loaded |
 | D4 | HDF5 returns group members sorted, worked around by a regex "natural sort" that silently falls back to lexicographic order unless *every* key matches `^\D+\d+$` | was `GML/ext/HDF5Ext.jl:87-97` | **fixed** — this package records key order as a group attribute, and GML's `_natural_sort_keys` is gone. `ext/HDF5Ext.jl:217-221` keeps the regex guess for files that record nothing better, guarded so it leaves the order alone unless every key matches |
 | D5 | `unflatten` rebuilds a manifold via `Base.typename(typeof(x)).wrapper`; the comment records that hardcoding `StiefelManifold` previously turned a `GrassmannManifold` into one on every round trip | `GO/…/named_tuple_wrapper.jl:16-23, 78-79` | open in GO — step 2 of the GO work in §8. Not a defect here: `rebuild` takes a prototype, so the concrete type cannot drift |
 | D6 | `ParameterHandling.flatten` defaults to `Float64`, silently promoting `Float32` networks | `GO/…/named_tuple_wrapper.jl:14` | open in GO — step 2 of the GO work in §8. Not a defect here: `flatten(ps)` takes its element type from `parameter_eltype(ps)` |
 | D7 | With the type moved out of ANN, `ZygoteRules.pullback(f::Function, ::NeuralNetworkParameters)` owns neither argument type and becomes piracy there | was `ANN/src/pullback_for_applychain.jl:10-17` | **fixed** — the generic method is `ext/ZygoteRulesExt.jl:17`, and `ANN/src/pullback_for_applychain.jl:10-14` records the move |
-| D8 | GML's `h5save(::H5DataStore, ::StiefelManifold, ::AbstractString)` and `changebackend(::NeuralNetworkBackend, ::StiefelManifold)` are genuine type piracy — the generics are ANN's and the types are GO's, so GML owns nothing in either signature | `GML/ext/HDF5Ext.jl` | **half fixed.** The `h5save` half is gone: GML's extension defines no `h5save` at all, and GO's `ext/NeuralNetworkParametersExt.jl` serves the types through the protocol. The `changebackend` half is open — see D3 |
+| D8 | GML's `h5save(::H5DataStore, ::StiefelManifold, ::AbstractString)` and `changebackend(::NeuralNetworkBackend, ::StiefelManifold)` are genuine type piracy — the generics are ANN's and the types are GO's, so GML owns nothing in either signature | `GML/ext/HDF5Ext.jl` | **fixed, both halves.** The `h5save` half went with GML's extension, which defines no `h5save` at all; the `changebackend` half went to `GO/ext/AbstractNeuralNetworksExt.jl` — see D3. `GML/ext/HDF5Ext.jl` is 86 lines and is `save`/`load` entry points and nothing else |
 | D9 | `Base.NamedTuple(p::NeuralNetworkParameters)` — Base's constructor and ANN's type, so the package defining it owns neither. Surfaced by GML [#207](https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/207) | was `GML/src/layers/forcing_dissipation_layers.jl` | **fixed, phase 1** — `src/parameters.jl:162` |
 | D10 | `h5save(::HDF5.Group, ::NeuralNetworkParameters, ::AbstractString)` — ANN's generic and ANN's type, from GML. Nothing existed for a parameter set nested at a path, which the parameter-dependent architectures produce. Also GML [#207](https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/207) | was `GML/ext/HDF5Ext.jl` | **fixed** — `src/io.jl` owns the generic HDF5 path, so a nested parameter set serialises without anybody committing piracy |
-| D11 | `GeometricOptimizers.GlobalSection(ps::NetworkParameters)` — `GlobalSection` is GO's and `NetworkParameters` is this package's, so GML owns neither. Not in the original survey; it appeared when GML adopted the container while GO had not | `GML/src/optimizers/optimizer.jl:5-6` | open. Fixed by step 3 of the GO work in §8, which gives it a home next to `GO/src/global_sections/global_sections.jl:29` |
+| D11 | `GeometricOptimizers.GlobalSection(ps::NetworkParameters)` — `GlobalSection` is GO's and `NetworkParameters` is this package's, so GML owns neither. Not in the original survey; it appeared when GML adopted the container while GO had not | was `GML/src/optimizers/optimizer.jl` | **fixed** — GO owns it, at `GO/src/global_sections/global_sections.jl:45`, and deliberately returns a plain `NamedTuple` tree rather than a container: a section is not a parameter |
 | D12 | **The walks were superlinear in the width of one branch.** Every across-children walk was an `@inline`d `Base.tail` chain, and `Base.tail` yields a new tuple type per level — so `k` children cost `k` specialisations over `O(k)`-long argument types and inference grew as `k³`. `flatten` on a flat 369-leaf set, the MNIST transformer of GMLDatasets, did not finish | was `src/flatten.jl`, `src/walk.jl`, `src/leaves.jl`, `src/layout.jl`, `src/derivatives.jl` | **fixed, 0.2.2** — written out as `@generated` flat bodies at literal indices. 369 leaves: `flatten` 2.05 s, `mapparameters` 0.00 s. Julia 1.11 is the compat floor as a consequence: 1.10 cannot inline a `@generated` body, and that inlining is what D13 needs |
 | D13 | `flatten!`/`unflatten!` allocated past about forty children — 81 488 bytes at 48, 187 808 at 64 — against the guarantee in their own docstrings, because `values(ps)` and `values(l.children)` materialise a temporary tuple per branch | was `src/flatten.jl` | **fixed, 0.2.2** — the walks index the branch in place with `getfield` and take no `values`. Zero at every width and every depth, on Julia 1.11, 1.12 and 1.13 |
 | D14 | The reverse pass had D13's defect too: 70 592 bytes per pullback call at 48 children, 161 504 at 64 | was `src/derivatives.jl` | **fixed, 0.2.2** — `_accumulate_named!` splices the branch's keys in as literals, which is also what keeps `_cotangent_get`'s `haskey` a compile-time question |
+| D15 | **The `@generated` walks raised `MethodError: … may be too new` when the sources are evaluated rather than loaded from a cache.** `_map_zip` and `_foreach_zip` called `_children_arity` from their *generator* bodies, and it was defined below them in the same file; a generator runs in the world age of its own method definition, so it was invisible. Precompilation hides this by giving every method in a module one world age, which is why the whole suite passed with it present | was `src/walk.jl:277,284` vs `:311` | **fixed, 0.2.2** — the helper is defined above every caller, and `test/world_age_tests.jl` runs the walks in a subprocess under `--compiled-modules=no`, which is the only way to ask |
+| D16 | **`scripts/wide_branch_cost.jl` swept its widths in one process, so every row but the first measured what its predecessors had compiled.** Every figure the 0.2.2 work first quoted was wrong — `flatten` on 0.2.1 at 128 children was recorded as 17.57 s against 2.08 s cold, and at 369 as "not run to completion" against 12.82 s, and `mapparameters` read as `0.00 s` where cold it was 1.51 s. `GeometricOptimizers` closed an issue of its own on that `0.00 s` and deleted a file on the strength of it | was `scripts/wide_branch_cost.jl` | **fixed, 0.2.2** — one process per width, and the `--cold-map` flag deleted with the need for it. A measurement you have to ask for in a special way is one the default run is getting wrong |
 
 D8's two halves are the clearest evidence for the protocol, and they were fixed by different packages
 at different times. With the structured types upstream of the package that trains with them, a
@@ -395,26 +425,32 @@ Also still open and not a parameter-container matter: `l2norm(::AbstractMatrix)`
 `l2norm(::AbstractFloat)` are piracy on *Base* types and belong upstream in `GeometricBase`. No
 container fixes them, and GO's own comment says so.
 
-### `GeometricMachineLearning` 0.6.0 — the HDF5 half shipped
+### `GeometricMachineLearning` 0.6.1 — done
 
-`ext/HDF5Ext.jl` is 119 lines and defines no `h5save`: it is `save`/`load` entry points dispatching on
-GML's own `NeuralNetwork`, delegating the traversal here. `_natural_sort_keys` is gone (D4), and so is
-the pirated `h5save` (half of D8). The package depends on this one (`Project.toml:19`) and re-exports
-`NetworkParameters` (`src/GeometricMachineLearning.jl:106`).
+`ext/HDF5Ext.jl` is **86 lines** and defines no `h5save` and no `changebackend`: it is `save`/`load`
+entry points dispatching on GML's own `NeuralNetwork`, delegating the traversal here.
+`_natural_sort_keys` is gone (D4), the pirated `h5save` is gone (half of D8), and the five
+`changebackend` methods moved to `GO/ext/AbstractNeuralNetworksExt.jl` in GO 0.5.0, which closed D3
+and the other half of D8. `GlobalSection(::NetworkParameters)` went the same way, closing D11. The
+package depends on this one (`Project.toml:19`) and re-exports `NetworkParameters`
+(`src/GeometricMachineLearning.jl:106`).
 
 **`ParameterSet` replaced fifteen inline unions**, across `loss/`, `optimizers/optimizer.jl`,
 `pullbacks/zygote_pullback.jl` and `data_loader/optimize.jl`.
 
-**What remains.** The five `changebackend` methods for GO's types are still inside the HDF5 extension
-(`ext/HDF5Ext.jl:23-41`) — D3 and the other half of D8. `ext/HDF5Ext.jl:17-20` records why they are
-still there and where they belong: a `GeometricOptimizers` extension on `AbstractNeuralNetworks`, which
-is GO's release chain rather than GML's, so it is a separate change. Beyond that, `src/map_to_cpu.jl`
-still hand-recurses with six per-type methods where one `mapparameters` call would do;
-`src/utils.jl` still carries `apply_toNT` (`:31-36`, still exported at
-`src/GeometricMachineLearning.jl:174`) and `_eltype` (`:225-237`); and the step dispatcher
-`_tree_optim_step!` (`src/optimizers/optimizer.jl:252-264`) is one more hand-written recursion over the
-same shape, which `foreachparameters` covers — including the `nothing`-branch skip it open-codes at
-`:256`.
+**What remains, and it is one thing kept on purpose.** `src/map_to_cpu.jl` is one `mapstorage` call;
+`apply_toNT` and `_eltype` are gone. The step dispatcher `_tree_optim_step!`
+(`src/optimizers/optimizer.jl:270-292`) stays hand-written, and now says why: it recurses on the
+*cache* tree and stops where the cache stops, so a layer's `NamedTuple` reaches `_leaf_optim_step!`
+whole, which is what one `GeometricOptimizers` cache is for; and `λY` is broadcast rather than zipped,
+one `GlobalSection` standing in for a whole subtree. `foreachparameters` does neither. Three earlier
+revisions of this section listed `map_to_cpu`, `apply_toNT`/`_eltype` and the `changebackend` methods
+here after they had been done.
+
+The comment on `_make_optimizer_cache`'s branch ordering was **wrong for a release** and is corrected:
+it said the ordering was invisible because `NetworkParameters` is not one of the types
+`OptimizerSolution` unions, and GO 0.5.0 had made it one, so the ordering is load-bearing. The code
+was already right; only the comment was not.
 
 ### `NonlinearIntegrators` 0.4.1 — a consumer
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,26 +1,39 @@
 # NeuralNetworkParameters.jl — analysis and plan
 
-Analysis last revised 2026-08-24, against these working trees:
+Analysis last revised 2026-08-26, against these working trees:
 
 | package | version | commit |
 |---|---|---|
-| `NeuralNetworkParameters` | 0.2.0 | this repository |
-| `AbstractNeuralNetworks` | 0.7.0 | `c324789` |
-| `SymbolicNeuralNetworks` | 0.6.0 | `1d568c0` |
-| `GeometricMachineLearning` | 0.6.0 | `6db0b98` |
-| `GeometricOptimizers` | 0.4.3 | `a8707f3` |
-| `NonlinearIntegrators` | 0.4.0 | `1288174` |
+| `NeuralNetworkParameters` | 0.2.2 | this repository |
+| `AbstractNeuralNetworks` | 0.7.1 | `c628a34` |
+| `SymbolicNeuralNetworks` | 0.7.0 | `c0a75e5` |
+| `GeometricMachineLearning` | 0.6.0 | `33a3ce6f` |
+| `GeometricOptimizers` | 0.5.0 | `4c9f443` (branch `preallocate-the-flat-buffers`) |
+| `NonlinearIntegrators` | 0.4.1 | `f8a6268` |
 
 Paths written `ANN/…`, `SNN/…`, `GML/…`, `GO/…`, `NLI/…` are relative to the corresponding sibling
 checkout.
 
-**Status.** Phase 1 is released and registered in General; 0.2.0 carries the element type of the
-leaves on the type, which is what `GeometricOptimizers` needs of a parameter set to take it as a
-solution — step 3 of §8. Phase 2 is complete: this package is where the parameter container lives,
-and `AbstractNeuralNetworks` 0.7.0 consumes it. Phase 3 is half done — `GeometricOptimizers` 0.4.3
-supplies the leaf protocol for its structured matrices, and `GeometricMachineLearning` 0.6.0 has
-handed the HDF5 traversal over — with a named remainder in both, set out in §8.
-`SymbolicNeuralNetworks` 0.6.0 adopted the layout type, which §8 had not asked it to.
+**Status.** Phase 1 is released and registered in General. Phase 2 is complete: this package is where
+the parameter container lives, and `AbstractNeuralNetworks` consumes it. **Phase 3 is done** —
+`GeometricOptimizers` 0.5.0 supplies the leaf protocol for its structured matrices *and* dropped
+`ParameterHandling`, and its 0.6.0 branch takes a `NetworkParameters` through the whole optimizer;
+`GeometricMachineLearning` 0.6.0 handed the HDF5 traversal over. `SymbolicNeuralNetworks` adopted the
+layout type, which §8 had not asked it to.
+
+Two things happened in 0.2.2 that no earlier draft of this document anticipated, and both came from
+*outside* — from the review of `GeometricOptimizers` #68 and #69 rather than from this plan:
+
+- **D12, the walks were unusable on a wide branch**, which is a defect of this package that the
+  consolidation argument in §2 depended on not existing. It is fixed; see §4.
+- **`ParameterSet`**, one name for `Union{NetworkParameters, NamedTuple}`, which every consumer had
+  been spelling out for itself. See §6 and §8.
+
+The lesson §3 draws — that a status claim here is worth what the last check against the sibling
+checkouts was worth — now has a companion: a *design* claim is worth what the last consumer that tried
+to use it found. §2's "written once against the leaf protocol, one implementation covers all of them"
+was true in intent and false in practice for two years' worth of releases, and the package that noticed
+was the one that had to write its own walk instead.
 
 ---
 
@@ -115,9 +128,17 @@ checkouts, so §8 is now written as *where each package stands* rather than as a
 
 ## 4. Defects on record
 
-D1, D2, D4, D7, D9, D10 and half of D8 are fixed. The rest are noted so they are not lost; the status
-column says where each stands. D11 is new since the last revision — the piracy inventory grows as
-packages adopt the container ahead of the ones they depend on.
+D1, D2, D4, D7, D9, D10, D12, D13, D14 and half of D8 are fixed. The rest are noted so they are not
+lost; the status column says where each stands. D11 is new since the 2026-08-19 revision — the piracy
+inventory grows as packages adopt the container ahead of the ones they depend on.
+
+**D12, D13 and D14 are this package's own, and none of them was found here.** All three came from the
+review of `GeometricOptimizers` #68, which needed `mapparameters` on the one parameter shape it has a
+named consumer for and could not compile it. They are grouped because they are one cliff seen from
+three sides — compile time, forward allocations, reverse allocations — and because two of them
+contradicted docstrings in this repository that the test suite was affirming, since every set it tested
+was narrow enough to stay below the cliff. `test/wide_branch_tests.jl` is the width a consumer actually
+has, and `scripts/wide_branch_cost.jl` is the harness.
 
 | # | defect | location | status |
 |---|---|---|---|
@@ -132,6 +153,9 @@ packages adopt the container ahead of the ones they depend on.
 | D9 | `Base.NamedTuple(p::NeuralNetworkParameters)` — Base's constructor and ANN's type, so the package defining it owns neither. Surfaced by GML [#207](https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/207) | was `GML/src/layers/forcing_dissipation_layers.jl` | **fixed, phase 1** — `src/parameters.jl:162` |
 | D10 | `h5save(::HDF5.Group, ::NeuralNetworkParameters, ::AbstractString)` — ANN's generic and ANN's type, from GML. Nothing existed for a parameter set nested at a path, which the parameter-dependent architectures produce. Also GML [#207](https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/207) | was `GML/ext/HDF5Ext.jl` | **fixed** — `src/io.jl` owns the generic HDF5 path, so a nested parameter set serialises without anybody committing piracy |
 | D11 | `GeometricOptimizers.GlobalSection(ps::NetworkParameters)` — `GlobalSection` is GO's and `NetworkParameters` is this package's, so GML owns neither. Not in the original survey; it appeared when GML adopted the container while GO had not | `GML/src/optimizers/optimizer.jl:5-6` | open. Fixed by step 3 of the GO work in §8, which gives it a home next to `GO/src/global_sections/global_sections.jl:29` |
+| D12 | **The walks were superlinear in the width of one branch.** Every across-children walk was an `@inline`d `Base.tail` chain, and `Base.tail` yields a new tuple type per level — so `k` children cost `k` specialisations over `O(k)`-long argument types and inference grew as `k³`. `flatten` on a flat 369-leaf set, the MNIST transformer of GMLDatasets, did not finish | was `src/flatten.jl`, `src/walk.jl`, `src/leaves.jl`, `src/layout.jl`, `src/derivatives.jl` | **fixed, 0.2.2** — written out as `@generated` flat bodies at literal indices. 369 leaves: `flatten` 2.05 s, `mapparameters` 0.00 s |
+| D13 | `flatten!`/`unflatten!` allocated past about forty children — 81 488 bytes at 48, 187 808 at 64 — against the guarantee in their own docstrings, because `values(ps)` and `values(l.children)` materialise a temporary tuple per branch | was `src/flatten.jl` | **fixed, 0.2.2** — the walks index the branch in place with `getfield` and take no `values`. Zero at every width |
+| D14 | The reverse pass had D13's defect too: 70 592 bytes per pullback call at 48 children, 161 504 at 64 | was `src/derivatives.jl` | **fixed, 0.2.2** — `_accumulate_named!` splices the branch's keys in as literals, which is also what keeps `_cotangent_get`'s `haskey` a compile-time question |
 
 D8's two halves are the clearest evidence for the protocol, and they were fixed by different packages
 at different times. With the structured types upstream of the package that trains with them, a
@@ -177,7 +201,7 @@ copy semantics, with allocation-free in-place variants for inner loops.
 
 | file | contents |
 |---|---|
-| `src/parameters.jl` | `NetworkParameters`, `params`, and the `NamedTuple` forwarding |
+| `src/parameters.jl` | `NetworkParameters`, `params`, `ParameterSet`, and the `NamedTuple` forwarding |
 | `src/leaves.jl` | `freeparameters`, `rebuild`, `parameter_metadata`, `parameter_eltype`, `isterminal`, `isparametertree` |
 | `src/walk.jl` | `mapparameters`, `mapstorage`, the in-place and `foreach` forms, `foldparameters` |
 | `src/layout.jl` | `ParameterLayout` and its five concrete cases, `parameterlayout`, `parameterrange`, `flatlength` |
@@ -189,6 +213,23 @@ copy semantics, with allocation-free in-place variants for inner loops.
 | `ext/ZygoteRulesExt.jl` | `pullback` on a `NetworkParameters`, D7's new home |
 
 Design points worth keeping in view:
+
+- **`ParameterSet` is the dispatch type; `NetworkParameters` is the container.** New in 0.2.2, and it
+  is the answer to a question this document never asked: what should a method take when it wants *the
+  parameters* and does not care which of the two forms it was handed? Every consumer had answered it
+  separately — `Union{NamedTuple, NetworkParameters}` inline at eight sites in `AbstractNeuralNetworks`
+  and fifteen in `GeometricMachineLearning`, `const EquationSet` in `SymbolicNeuralNetworks`, and in
+  `GeometricOptimizers` a *narrower* alias, `ParameterContainer{T}`, plus sixteen inline fallbacks
+  where that one did not fit.
+
+  It is keyed only, and deliberately not `isparametertree`'s domain, which also admits a `Tuple`: a
+  `Tuple` is a branch the walks recurse into — it is what `freeparameters` returns for a multi-block
+  leaf, and why `TupleLayout` exists — but never a set of parameters handed in whole. The two agree on
+  everything except the `Tuple`s, and `test/parameters_tests.jl` asserts exactly that rather than the
+  happy path.
+
+  It also puts **no bound on the element type and none on the depth**, which is the whole difference
+  from `GeometricOptimizers.ParameterContainer{T}` — see §8 for why that one has to exist as well.
 
 - **The leaf protocol is the whole extension surface.** `freeparameters(x)` gives the differentiable
   storage, `rebuild(prototype, data)` puts a leaf back. `freeparameters` may return an array, a scalar,
@@ -215,9 +256,20 @@ Design points worth keeping in view:
 ### Verification
 
 ```bash
-julia --project -e 'using Pkg; Pkg.test()'                                            # 255 tests
+julia --project -e 'using Pkg; Pkg.test()'                                            # 388 tests
 julia --project=docs -e 'using Pkg; Pkg.develop(path="."); include("docs/make.jl")'   # doctests
+julia --project=. scripts/wide_branch_cost.jl                                         # D12/D13
+julia --project=. scripts/wide_branch_cost.jl --cold-map                              # D12, cold
 ```
+
+It also covers a **369-child branch** — the width of GMLDatasets' MNIST transformer, and the shape D12,
+D13 and D14 were about — through `flatten`/`unflatten`, `mapparameters` at both arities,
+`mapparameters!`, `foreachparameters` with and without the `nothing` skip, `foldparameters`, the
+`unflatten` pullback, and the in-place forms at zero allocations. It asserts the properties and not the
+timings, because a wall-clock bound would be a flake on a loaded machine; the regression test is that
+the file *completes*, which before 0.2.2 it did not. It costs the suite about 40 s, all of it
+compilation at that width, and that is the price of covering the width a consumer has rather than the
+width that is convenient.
 
 The suite covers, beyond round trips: `Float32` fidelity (D6); zero allocation for `flatten!` and
 `unflatten!` — measured from inside a function, since a top-level `@allocated` reports a few tens of
@@ -254,7 +306,7 @@ structured types anyway — the same extension work plus a dependency.
 
 ## 8. Where each package stands
 
-### `AbstractNeuralNetworks` 0.7.0 — done
+### `AbstractNeuralNetworks` 0.7.1 — done
 
 The container moved. `src/parameters.jl` and the whole `ext/` directory are gone; the package depends
 on this one (`Project.toml:10`, compat `:19`) and imports the five names it extends or reaches through
@@ -263,6 +315,13 @@ on this one (`Project.toml:10`, compat `:19`) and imports the five names it exte
 replaces did not have; `_statify` is another (`src/static_cpu_backend.jl:30`). D7's generic `pullback`
 moved here. `test/parameters_tests.jl` and `test/parameters_hdf5_tests.jl` became
 `test/parameters_seam_tests.jl`, which tests the seam rather than the container.
+
+**`ParameterSet` replaced eight inline unions** (`chain.jl:52`, `model.jl:35`, `losses.jl:90,95,99`,
+`static_cpu_backend.jl:30`, `utils/changebackend.jl:16`). Note that ANN's own `ArrayNamedTuple`
+(`src/utils/array_named_tuple.jl:23`) is a *different* thing and stays: it is about network inputs and
+outputs rather than parameters, and it is the one name it shares with `GeometricOptimizers` by
+coincidence. Worth renaming to leave `ArrayOrNamedTuple` alone as the only name there, but that is
+cosmetic and not done.
 
 **The compatibility alias was deliberately not added.** Earlier drafts of this section called for
 `const NeuralNetworkParameters = NetworkParameters` and a re-export, and listed the downstream uses it
@@ -275,7 +334,12 @@ site the survey found now names `NetworkParameters`: `src/chain.jl:52,57` and
 that used to build the container by keys went further and no longer build one at all: the nested walk
 in `SNN/src/derivatives/derivative.jl:26` is `mapparameters`.
 
-### `SymbolicNeuralNetworks` 0.6.0 — done, and more than was asked
+### `SymbolicNeuralNetworks` 0.7.0 — done, and more than was asked
+
+**`EquationSet` is gone.** It was `Union{NamedTuple, NetworkParameters}`, and this was the only package
+in the ecosystem to have given that union a name — which is why `ParameterSet` is named after the shape
+rather than after the contents. `EquationSetFunction` and `EquationSetArrayFunction` keep their names;
+they are named for what they carry.
 
 Earlier drafts said this package needed no change, on the grounds that its `flatten_equations` solves a
 different problem. That was half right: restoring batch dimensions is still its own
@@ -285,123 +349,51 @@ different problem. That was half right: restoring batch dimensions is still its 
 `ParameterLayout` (`:159-160`). The design point in §6 that called `ParameterLayout` a generalisation
 of `FlatSlice` turned out to be the plan for a package this document said to leave alone.
 
-### `GeometricOptimizers` 0.4.3 — the leaf protocol shipped
+### `GeometricOptimizers` 0.5.0, and 0.6.0 on the branch — done
 
-`ext/NeuralNetworkParametersExt.jl` supplies the whole protocol for GO's structured matrices: one
-`freeparameters(x) = parent(x)` covering all three families, eight `rebuild` methods, a guard method on
-the abstract types that raises rather than letting `rebuild(::AbstractArray, data) = data` hand back
-bare storage for a subtype added later, `parameter_metadata`, and `register_parameter_type!` for all
-eight types — including normalisation for the older layout GML used to write, which is the only place
-that can do it, since it is where the types are.
+All three steps this section used to set out have shipped, and not in the order it predicted.
 
-**What remains.** GO still depends on `ParameterHandling` (`Project.toml:13`), still carries the
-pirated Base-type `flatten` methods and the `Float64`-defaulting one-arg method
-(`src/optimizers/named_tuple_wrapper.jl:12-66`), and still dispatches on `ArrayNamedTuple` — a bare
-`NamedTuple` alias (`src/optimizer_solution.jl:48-52`) — rather than on a type it owns. The work, in
-order:
+**Steps 1 and 2 shipped together in 0.5.0**, as one breaking release rather than the patch this section
+proposed: `ParameterHandling` is gone, `ext/NeuralNetworkParametersExt.jl` supplies the whole leaf
+protocol for GO's structured matrices, the flat buffers are preallocated on the quasi-Newton caches, and
+`NetworkParameters{T}` is a member of `OptimizerSolution{T}`. D5 and D6 went with it: `rebuild` takes a
+prototype, so the concrete type cannot drift, and `flatten(ps)` takes its element type from the
+parameters.
 
-**1. Preallocate the flat buffers.** A layout is a value, so it can live on the cache; the
-`ParameterHandling` closure could not. Three sites flatten purely to obtain a length —
-`iterative_hessians/bfgs/bfgs_cache.jl:33`, `.../dfp/dfp_cache.jl:37`, `.../bfgs/bfgs_state.jl:46` —
-where `flatlength(x)` suffices and allocates nothing. The rest flatten per call, and become `flatten!`
-into cache scratch: `outer!` (`bfgs_cache.jl:90-93`, and the lift form at `:109-112`),
-`bfgs_cache.jl:161`, `dfp_cache.jl:113`, `bfgs_state.jl:91`, `_mul!` (`named_tuple_wrapper.jl:228-234`
-and `:240-246`, twice per call each) and `_dot` (`:279-280`, both arguments per inner product, once per
-line-search trial slope — the hottest of them). The write-back becomes `unflatten!`, which
-`ParameterHandling` had no equivalent of at all.
+**Step 3 is the 0.6.0 branch** (#68 and #69). The elementwise primitives and the ~40 sites around them
+take a container, and a nested container now runs `solve!`, `BFGS` and `DFP` — which is what this
+section meant by "the swap". Two things it predicted came out differently:
 
-**2. Drop `ParameterHandling`.** With the call sites moved,
-`src/optimizers/named_tuple_wrapper.jl:12-93` goes: the one-arg method at `:14` (D6), the five
-Base-type methods at `:30-66`, and the four GO-owned methods at `:16-23, 76-93`, which
-`ext/NeuralNetworkParametersExt.jl` already supersedes. That retires `manifold_constructor`'s use in
-flattening (D5) — `rebuild` takes a prototype, so the concrete type cannot drift — though
-`manifold_constructor` itself still has a caller in `_similar` (`:126`). Then the dependency, the
-import at `src/GeometricOptimizers.jl:49`, and the four docstrings that describe its behaviour
-(`manifolds/abstract_manifold.jl:158,164`, `special_matrices/vector_storage_matrix.jl:18`,
-`named_tuple_wrapper.jl:6`).
+- **The trap did not fire.** This section warned that adding `NetworkParameters` to `OptimizerSolution`
+  would invert GML's `_use_go_cache` test and `MethodError` on the first training step. GML had already
+  put the `NetworkParameters` branch *ahead* of `_use_go_cache` in anticipation, so the inversion is
+  harmless. What was wrong was the comment beside it, which still said the ordering was invisible —
+  0.5.0 had made it load-bearing a release earlier. Corrected in GML.
 
-The ordering agrees leaf family by leaf family, which is what makes this behaviour-preserving:
+- **#16 is not closed, but one of its five sites is gone.** Closing the group needs the `NamedTuple`
+  methods *removed*, and they cannot be: GML hands GO one bare layer `NamedTuple` per layer, and
+  GMLDatasets' MNIST scripts pass a flat `NamedTuple` directly. But `outer!` on a parameter set turned
+  out to be *internal* to the quasi-Newton caches once #69 routed it through the flat buffers — no
+  consumer calls it — so it could simply be deleted. That is the distinction to apply to the other four:
+  ask whether a consumer reaches the generic, not whether the signature is pirated.
 
-| leaf | `ParameterHandling`, as GO wrote it | this package |
-|---|---|---|
-| plain array | `vec(x)` | `copyto!` in linear index order (`src/flatten.jl:103-104`) |
-| `Manifold` | `flatten(T, x.A)` | `parent(x) = A.A` (`GO/…/abstract_manifold.jl:147`) — the same array |
-| `VectorStorageMatrix` | `vec(s)` | `parent(x) = A.S`, and `Base.vec` *is* `.S` for all four (`symmetric.jl:297`, `skew_symmetric.jl:293`, `triangular.jl:124`) |
-| `StiefelLieAlgHorMatrix` | `flatten(T, (g.A, g.B))` | `parent = (A.A, A.B)`, recursed in tuple order; `g.A` is a `SkewSymMatrix` and reduces to `.S` on both sides |
-| `GrassmannLieAlgHorMatrix` | `flatten(T, g.B)` | `parent = (A.B,)` — the same numbers, one tuple level deeper |
-| `NamedTuple` | `flatten(T, values(x))`, depth first | `NestedLayout` over `values`, depth first (`src/layout.jl:130-133`) |
+**What `ParameterContainer{T}` is for, and why `ParameterSet` does not replace it.** GO keeps a narrower
+alias, `Union{ArrayNamedTuple{T}, NetworkParameters{T}}`, and it has to. `T` means two different things
+across it — for `ArrayNamedTuple{T}` a guarantee that every leaf is an `AbstractArray{T}` *and* that the
+set is flat, for `NetworkParameters{T}` a promotion over leaves at any depth — so it is the right type
+exactly where `T` also appears elsewhere in the signature, beside a `Matrix{T}` or an `f̄::T`, and the
+wrong type everywhere else. The sixteen sites that had to fall back to the inline union are the
+measurement of that, and they take `ParameterSet` now.
 
-So `GO/test/named_tuple_parameters.jl:21-22` keeps its hardcoded ranges and `∇F!` keeps indexing the
-flat vector the same way. Pin it with an elementwise-equality test while both packages are still
-present, before the deletion.
+**The remainder, and it is small.** `src/parameter_walks.jl` still holds `_mapleaves`, written there
+because `mapparameters` could not be compiled on a wide-flat set (D12). That is fixed, so the file can
+go; the one question left is that `_as_walkable` has a catch-all where `_as_namedtuple` does not, so a
+tree zipped against something that is neither a branch nor `nothing` at that level walks there and
+raises here. Nothing in GO does that. The in-place half is already `foreachparameters`.
 
-**3. Adopt `NetworkParameters`.** Everything funnels through `OptimizerSolution`
-(`src/optimizer_solution.jl:59`), so this is one alias plus the methods behind it. Note that
-`ArrayNamedTuple` is *flat*, so GO does not today accept a nested per-layer tree at all. Adding
-`NetworkParameters` to the union is non-breaking, and most of the ~28 `ArrayNamedTuple` methods in
-`named_tuple_wrapper.jl` are `apply_toNT` calls that become `mapparameters` — one method covering both
-containers and nested branches, so the file shrinks rather than doubling. That also retires the
-`apply_toNT` duplicated at `src/utils.jl:44`. Narrowing the piracy sites to `NetworkParameters`
-afterwards is what closes the non-`flatten` half of issue #16:
-`(grad::Gradient{T})(::ArrayNamedTuple{T})` (`named_tuple_wrapper.jl:97`),
-`Base.copyto!(::GlobalSectionNamedTuple, ::ArrayNamedTuple)` (`:141`), `outer!`
-(`bfgs_cache.jl:90`), `solution_scale` (`optimizer_status.jl:163`) and `l2norm` (`:185`).
-
-One caveat: `l2norm(::AbstractMatrix)` and `l2norm(::AbstractFloat)` (`optimizer_status.jl:181-182`)
-are piracy on *Base* types, and no parameter container fixes them. The comment at `:178-180` already
-says where they belong, which is upstream in `GeometricBase`.
-
-This is a breaking release — GO 0.5.0, by the convention its own `CHANGELOG.md:5-7` states — because
-the `ParameterHandling.flatten` methods are observable, and GO's own tests call them
-(`test/lie_algebras/grassmann_lie_algebra_horizontal.jl:86`,
-`test/special_matrices/optimizer_primitives.jl:96`).
-
-**Steps 1 and 2 are separable from step 3, and should ship first.** Nothing in them widens a
-signature or moves an exported name, so they can go out on GO's own schedule — as a patch, even, since
-the flat representation is unchanged. Step 3 cannot: it has to be co-released with GML.
-
-**The trap in step 3.** GML does not hand a parameter set to GO's container machinery today. It walks
-the tree itself (`GML/src/optimizers/optimizer.jl:252-264`) and calls GO's primitives per *leaf*
-(`:206-243`), and which of the two happens is decided by `_use_go_cache`
-(`:52-53`) — `x isa GeometricOptimizers.OptimizerSolution` — tested *before* the
-`x isa NamedTuple || x isa NetworkParameters` recursion (`:56-58`, `:67-69`). Since
-`NetworkParameters` is not in `OptimizerSolution` today, a whole network takes the recursion branch and
-each *layer* — a bare `NamedTuple` of arrays, i.e. an `ArrayNamedTuple` — gets its own GO cache.
-
-Adding `NetworkParameters` to `OptimizerSolution` inverts that: the top-level parameter set matches
-`_use_go_cache` instead, the recursion never runs, one cache is built for the whole network, and
-`_leaf_optim_step!` hands a `NetworkParameters` to `_GMLGradient`, which has methods only for
-`ArrayNamedTuple` (`:21`) and `AbstractArray` (`:23`). That is a `MethodError` on the first training
-step of every GML run — from a change that looks purely additive on GO's side. So step 3 needs a GML
-release that adds `(g::_GMLGradient)(::NetworkParameters)` and then either drops `_tree_optim_step!` in
-favour of the single whole-network cache, which is the better end state, or reorders the two tests.
-
-Two smaller couplings to respect: `GeometricOptimizers.apply_toNT` is called qualified from
-`GML/src/optimizers/optimizer.jl:19`, so the *name* has to survive even though GO stops using it
-internally — reimplement it as `mapparameters` rather than delete it. And
-`GML/src/optimizers/optimizer.jl:5-6` defines `GeometricOptimizers.GlobalSection(::NetworkParameters)`,
-which is GO's function on this package's type: GML owns neither, so it is piracy of the same shape as
-D8 (see D11). Step 3 is what gives it a legal home, next to
-`GO/src/global_sections/global_sections.jl:29`.
-
-**Two differences that are not ordering**, and are the only behaviour changes in step 2:
-`ParameterHandling`'s `flatten(T, ::Vector{R})` returned an `unflatten` that converted back to `R`
-(`GO/…/named_tuple_wrapper.jl:56-60`), where `unflatten` here keeps `eltype(v)` — identical for a
-homogeneous set, which `ArrayNamedTuple{T}` guarantees, and a reason to prefer `unflatten!` on the hot
-paths anyway, since writing through `copyto!` into an existing leaf cannot change its type. And an
-empty set flattens to `Vector{Union{}}` rather than `T[]`, because `_promote_eltypes(()) = Union{}`
-(`src/leaves.jl:204`); GO never constructs one. Since the container carries its element type, that
-`Union{}` is visible on the type as well as in `flatten`'s output: an empty set is a
-`NetworkParameters{Union{}}`, which binds and dispatches like any other.
-
-`GO/test/named_tuple_parameters.jl` is the gate for all three steps: it covers the heterogeneous
-`NamedTuple` (`:100-107`), `Float32` fidelity (`:109-123`) and manifold-kind preservation
-(`:125-147`), which are D6 and D5 seen from GO's side. Its `ParameterHandling.flatten(ps)` calls become
-`flatten`/`unflatten(layout, v)`; the assertions do not change.
-`GO/test/neural_network_parameters_protocol.jl` already exercises the protocol and `flatlength`, so
-extend that rather than starting a file. Worth adding for step 1: an `@allocated == 0` assertion on the
-`_dot` and `_mul!` paths, measured from inside a function as `test/flatten_tests.jl:85-102` does here,
-since that is the only way to know the preallocation landed.
+Also still open and not a parameter-container matter: `l2norm(::AbstractMatrix)` and
+`l2norm(::AbstractFloat)` are piracy on *Base* types and belong upstream in `GeometricBase`. No
+container fixes them, and GO's own comment says so.
 
 ### `GeometricMachineLearning` 0.6.0 — the HDF5 half shipped
 
@@ -409,6 +401,9 @@ since that is the only way to know the preallocation landed.
 GML's own `NeuralNetwork`, delegating the traversal here. `_natural_sort_keys` is gone (D4), and so is
 the pirated `h5save` (half of D8). The package depends on this one (`Project.toml:19`) and re-exports
 `NetworkParameters` (`src/GeometricMachineLearning.jl:106`).
+
+**`ParameterSet` replaced fifteen inline unions**, across `loss/`, `optimizers/optimizer.jl`,
+`pullbacks/zygote_pullback.jl` and `data_loader/optimize.jl`.
 
 **What remains.** The five `changebackend` methods for GO's types are still inside the HDF5 extension
 (`ext/HDF5Ext.jl:23-41`) — D3 and the other half of D8. `ext/HDF5Ext.jl:17-20` records why they are
@@ -421,7 +416,7 @@ still hand-recurses with six per-type methods where one `mapparameters` call wou
 same shape, which `foreachparameters` covers — including the `nothing`-branch skip it open-codes at
 `:256`.
 
-### `NonlinearIntegrators` 0.4.0 — a consumer
+### `NonlinearIntegrators` 0.4.1 — a consumer
 
 Not a target of any phase, but it pins both this package (`Project.toml:16`) and
 `AbstractNeuralNetworks = "0.7"` (`:26`), and reaches for `NetworkParameters` directly

--- a/PLAN.md
+++ b/PLAN.md
@@ -151,9 +151,14 @@ checkouts, so §8 is now written as *where each package stands* rather than as a
 ## 4. Defects on record
 
 D1, D2, D3, D4, D7, D8, D9, D10, D11, D12, D13 and D14 are fixed — which is all of them but D5 and
-D6, and those two are open *in `GeometricOptimizers`* rather than here. D15 and D16 are new in this
-revision and are both defects of this package's own 0.2.2 work, found by running it rather than by
+D6, and those two are open *in `GeometricOptimizers`* rather than here. D15 through D19 are new in this
+revision and are all five defects of this package's own 0.2.2 work, found by running it rather than by
 reading it.
+
+**D17 and D18 came from reviewing 0.2.2 itself**, and the lesson is narrower than D16's and worth as
+much: D13 was fixed on the two walks the tests measured, and the three that take a second set were
+neither fixed nor measured — while being the walks that run every iteration rather than once. A
+guarantee holds where it is asserted and nowhere else.
 
 **Three entries in this table were stale when this revision began**, and all three in the same
 direction: D3, the `changebackend` half of D8, and D11 were recorded as open and had been fixed in
@@ -182,10 +187,13 @@ has, and `scripts/wide_branch_cost.jl` is the harness.
 | D10 | `h5save(::HDF5.Group, ::NeuralNetworkParameters, ::AbstractString)` — ANN's generic and ANN's type, from GML. Nothing existed for a parameter set nested at a path, which the parameter-dependent architectures produce. Also GML [#207](https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/207) | was `GML/ext/HDF5Ext.jl` | **fixed** — `src/io.jl` owns the generic HDF5 path, so a nested parameter set serialises without anybody committing piracy |
 | D11 | `GeometricOptimizers.GlobalSection(ps::NetworkParameters)` — `GlobalSection` is GO's and `NetworkParameters` is this package's, so GML owns neither. Not in the original survey; it appeared when GML adopted the container while GO had not | was `GML/src/optimizers/optimizer.jl` | **fixed** — GO owns it, at `GO/src/global_sections/global_sections.jl:45`, and deliberately returns a plain `NamedTuple` tree rather than a container: a section is not a parameter |
 | D12 | **The walks were superlinear in the width of one branch.** Every across-children walk was an `@inline`d `Base.tail` chain, and `Base.tail` yields a new tuple type per level — so `k` children cost `k` specialisations over `O(k)`-long argument types and inference grew as `k³`. `flatten` on a flat 369-leaf set, the MNIST transformer of GMLDatasets, did not finish | was `src/flatten.jl`, `src/walk.jl`, `src/leaves.jl`, `src/layout.jl`, `src/derivatives.jl` | **fixed, 0.2.2** — written out as `@generated` flat bodies at literal indices. 369 leaves: `flatten` 2.05 s, `mapparameters` 0.00 s. Julia 1.11 is the compat floor as a consequence: 1.10 cannot inline a `@generated` body, and that inlining is what D13 needs |
-| D13 | `flatten!`/`unflatten!` allocated past about forty children — 81 488 bytes at 48, 187 808 at 64 — against the guarantee in their own docstrings, because `values(ps)` and `values(l.children)` materialise a temporary tuple per branch | was `src/flatten.jl` | **fixed, 0.2.2** — the walks index the branch in place with `getfield` and take no `values`. Zero at every width and every depth, on Julia 1.11, 1.12 and 1.13 |
+| D13 | `flatten!`/`unflatten!` allocated past about forty children — 81 488 bytes at 48, 187 808 at 64 — against the guarantee in their own docstrings, because `values(ps)` and `values(l.children)` materialise a temporary tuple per branch | was `src/flatten.jl` | **fixed, 0.2.2** — the walks index the branch in place with `getfield` and take no `values`. Zero at every width and every depth, on Julia 1.11, 1.12 and 1.13. See D17: the fix reached the two forward walks and not the three that take a second set |
 | D14 | The reverse pass had D13's defect too: 70 592 bytes per pullback call at 48 children, 161 504 at 64 | was `src/derivatives.jl` | **fixed, 0.2.2** — `_accumulate_named!` splices the branch's keys in as literals, which is also what keeps `_cotangent_get`'s `haskey` a compile-time question |
 | D15 | **The `@generated` walks raised `MethodError: … may be too new` when the sources are evaluated rather than loaded from a cache.** `_map_zip` and `_foreach_zip` called `_children_arity` from their *generator* bodies, and it was defined below them in the same file; a generator runs in the world age of its own method definition, so it was invisible. Precompilation hides this by giving every method in a module one world age, which is why the whole suite passed with it present | was `src/walk.jl:277,284` vs `:311` | **fixed, 0.2.2** — the helper is defined above every caller, and `test/world_age_tests.jl` runs the walks in a subprocess under `--compiled-modules=no`, which is the only way to ask |
 | D16 | **`scripts/wide_branch_cost.jl` swept its widths in one process, so every row but the first measured what its predecessors had compiled.** Every figure the 0.2.2 work first quoted was wrong — `flatten` on 0.2.1 at 128 children was recorded as 17.57 s against 2.08 s cold, and at 369 as "not run to completion" against 12.82 s, and `mapparameters` read as `0.00 s` where cold it was 1.51 s. `GeometricOptimizers` closed an issue of its own on that `0.00 s` and deleted a file on the strength of it | was `scripts/wide_branch_cost.jl` | **fixed, 0.2.2** — one process per width, and the `--cold-map` flag deleted with the need for it. A measurement you have to ask for in a special way is one the default run is getting wrong |
+| D17 | **D13 was fixed on the two walks that were measured and not on the three that were not.** `mapparameters!`, `mapstorage!` and `foreachparameters` turned each *further* argument into a `values(...)` tuple per branch, and a skipped one into a fresh tuple of `nothing`s — 800 bytes a call on a flat 48-child set, 6 144 at 369, and three to four times that on a branch of branches. These are the walks an optimizer runs every iteration, where `flatten!` runs once or twice | was `src/walk.jl:152,196,293-297` | **fixed** — `_foreach_zip` reads every argument with `getfield` at a literal index; `_values_for` and `_tuple_for` are gone. Zero at every width, depth and arity. Not caught because measuring a `Vararg` method needs a zero-argument closure: `@allocated f(a, b)` lowers to `Base.allocated(f, a, b)`, whose own splat allocates |
+| D18 | **The in-place walks paired the children of two keyed branches by *position*.** `_values_for(x, ks)` ignored its `ks`, so two same-shaped sets whose keys were ordered differently wrote every leaf into the wrong parameter without a word, where `mapparameters` has always raised | was `src/walk.jl:293` | **fixed** — the generated body checks a named argument's keys against the branch's own, in the generator, so the guard is free at run time and stricter than `_check_keys`. A behaviour change: positional pairing of differently-keyed sets now raises |
+| D19 | **`scripts/wide_branch_cost.jl` still was not measuring compile time after D16.** `first_call` timed a direct `f(args...)`, and compiling `first_call` infers through that call — so the inference being timed was spent before its own `t = time()` ran. On Julia 1.13 the committed harness printed 0.00 s for every width in every column, where an opaque call measures 1.61 s for `parameterlayout` and 3.95 s for `flatten` at 369 children | was `scripts/wide_branch_cost.jl:38-42` | **fixed** — the call goes through `Base.invokelatest`. D16 and this are the same lesson from two ends: arrange the harness so the cost cannot have been paid somewhere the clock is not looking |
 
 D8's two halves are the clearest evidence for the protocol, and they were fixed by different packages
 at different times. With the structured types upstream of the package that trains with them, a
@@ -286,10 +294,9 @@ Design points worth keeping in view:
 ### Verification
 
 ```bash
-julia --project -e 'using Pkg; Pkg.test()'                                            # 388 tests
+julia --project -e 'using Pkg; Pkg.test()'                                            # 424 tests
 julia --project=docs -e 'using Pkg; Pkg.develop(path="."); include("docs/make.jl")'   # doctests
-julia --project=. scripts/wide_branch_cost.jl                                         # D12/D13
-julia --project=. scripts/wide_branch_cost.jl --cold-map                              # D12, cold
+julia --project=. scripts/wide_branch_cost.jl                                         # D12/D13/D17
 ```
 
 It also covers a **369-child branch** — the width of GMLDatasets' MNIST transformer, and the shape D12,

--- a/PLAN.md
+++ b/PLAN.md
@@ -153,8 +153,8 @@ has, and `scripts/wide_branch_cost.jl` is the harness.
 | D9 | `Base.NamedTuple(p::NeuralNetworkParameters)` — Base's constructor and ANN's type, so the package defining it owns neither. Surfaced by GML [#207](https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/207) | was `GML/src/layers/forcing_dissipation_layers.jl` | **fixed, phase 1** — `src/parameters.jl:162` |
 | D10 | `h5save(::HDF5.Group, ::NeuralNetworkParameters, ::AbstractString)` — ANN's generic and ANN's type, from GML. Nothing existed for a parameter set nested at a path, which the parameter-dependent architectures produce. Also GML [#207](https://github.com/JuliaGNI/GeometricMachineLearning.jl/pull/207) | was `GML/ext/HDF5Ext.jl` | **fixed** — `src/io.jl` owns the generic HDF5 path, so a nested parameter set serialises without anybody committing piracy |
 | D11 | `GeometricOptimizers.GlobalSection(ps::NetworkParameters)` — `GlobalSection` is GO's and `NetworkParameters` is this package's, so GML owns neither. Not in the original survey; it appeared when GML adopted the container while GO had not | `GML/src/optimizers/optimizer.jl:5-6` | open. Fixed by step 3 of the GO work in §8, which gives it a home next to `GO/src/global_sections/global_sections.jl:29` |
-| D12 | **The walks were superlinear in the width of one branch.** Every across-children walk was an `@inline`d `Base.tail` chain, and `Base.tail` yields a new tuple type per level — so `k` children cost `k` specialisations over `O(k)`-long argument types and inference grew as `k³`. `flatten` on a flat 369-leaf set, the MNIST transformer of GMLDatasets, did not finish | was `src/flatten.jl`, `src/walk.jl`, `src/leaves.jl`, `src/layout.jl`, `src/derivatives.jl` | **fixed, 0.2.2** — written out as `@generated` flat bodies at literal indices. 369 leaves: `flatten` 2.05 s, `mapparameters` 0.00 s |
-| D13 | `flatten!`/`unflatten!` allocated past about forty children — 81 488 bytes at 48, 187 808 at 64 — against the guarantee in their own docstrings, because `values(ps)` and `values(l.children)` materialise a temporary tuple per branch | was `src/flatten.jl` | **fixed, 0.2.2** — the walks index the branch in place with `getfield` and take no `values`. Zero at every width |
+| D12 | **The walks were superlinear in the width of one branch.** Every across-children walk was an `@inline`d `Base.tail` chain, and `Base.tail` yields a new tuple type per level — so `k` children cost `k` specialisations over `O(k)`-long argument types and inference grew as `k³`. `flatten` on a flat 369-leaf set, the MNIST transformer of GMLDatasets, did not finish | was `src/flatten.jl`, `src/walk.jl`, `src/leaves.jl`, `src/layout.jl`, `src/derivatives.jl` | **fixed, 0.2.2** — written out as `@generated` flat bodies at literal indices. 369 leaves: `flatten` 2.05 s, `mapparameters` 0.00 s. Julia 1.11 is the compat floor as a consequence: 1.10 cannot inline a `@generated` body, and that inlining is what D13 needs |
+| D13 | `flatten!`/`unflatten!` allocated past about forty children — 81 488 bytes at 48, 187 808 at 64 — against the guarantee in their own docstrings, because `values(ps)` and `values(l.children)` materialise a temporary tuple per branch | was `src/flatten.jl` | **fixed, 0.2.2** — the walks index the branch in place with `getfield` and take no `values`. Zero at every width and every depth, on Julia 1.11, 1.12 and 1.13 |
 | D14 | The reverse pass had D13's defect too: 70 592 bytes per pullback call at 48 children, 161 504 at 64 | was `src/derivatives.jl` | **fixed, 0.2.2** — `_accumulate_named!` splices the branch's keys in as literals, which is also what keeps `_cotangent_get`'s `haskey` a compile-time question |
 
 D8's two halves are the clearest evidence for the protocol, and they were fixed by different packages
@@ -267,14 +267,14 @@ D13 and D14 were about — through `flatten`/`unflatten`, `mapparameters` at bot
 `mapparameters!`, `foreachparameters` with and without the `nothing` skip, `foldparameters`, the
 `unflatten` pullback, and the in-place forms at zero allocations. It asserts the properties and not the
 timings, because a wall-clock bound would be a flake on a loaded machine; the regression test is that
-the file *completes*, which before 0.2.2 it did not. It costs the suite about 40 s, all of it
-compilation at that width, and that is the price of covering the width a consumer has rather than the
-width that is convenient.
+the file *completes*, which before 0.2.2 it did not. It costs the suite about 45 s on Julia 1.13 and
+about 1 m 45 s on 1.11, all of it compilation at that width, and that is the price of covering the
+width a consumer has rather than the width that is convenient.
 
 The suite covers, beyond round trips: `Float32` fidelity (D6); zero allocation for `flatten!` and
-`unflatten!` — measured from inside a function, since a top-level `@allocated` reports a few tens of
-bytes per leaf on Julia 1.10, where the recursion is not specialised; a structured leaf and a two-block
-leaf whose types survive the round trip (D5); scalar, empty and tuple leaves; `Dual`-valued
+`unflatten!` — measured from inside a function, which is the claim that matters, an optimizer's inner
+loop rather than the top level of a testset; a structured leaf and a two-block leaf whose types
+survive the round trip (D5); scalar, empty and tuple leaves; `Dual`-valued
 unflattening; agreement between `ForwardDiff` on the flat form and `Zygote` on the structured one;
 Zygote through both conversions; a structurally-zero gradient block; the `nothing`-branch skip in the
 walks; ten-layer HDF5 key ordering (D4); both HDF5 load paths; and files in the two older formats.

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ SafeTestsets = "0.1"
 Test = "1"
 Zygote = "0.6, 0.7"
 ZygoteRules = "0.2.7"
-julia = "1.10"
+julia = "1.11"
 
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralNetworkParameters"
 uuid = "67f4d93a-60e9-472b-8cdd-1ccf6005724a"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Michael Kraus <michael.kraus@ipp.mpg.de> and contributors"]
 
 [deps]

--- a/docs/src/conversions.md
+++ b/docs/src/conversions.md
@@ -93,9 +93,7 @@ needs. A `Float64` buffer cannot be shared with a `Dual`-valued view.
 
 Where repeated conversion does matter is an inner loop — an optimizer flattening twice per inner
 product. That is what [`flatten!`](@ref) and [`unflatten!`](@ref) are for: given a layout and a buffer,
-both allocate nothing when called from compiled code. (From an uninferred context, such as the top level
-of a script, the recursion is not specialised and costs a few tens of bytes per leaf on Julia 1.10 —
-which is what the package's own allocation tests measure inside a function to avoid.)
+both allocate nothing, at any width of branch and any depth of nesting.
 
 ```jldoctest
 using NeuralNetworkParameters

--- a/docs/src/representations.md
+++ b/docs/src/representations.md
@@ -9,6 +9,7 @@ CurrentModule = NeuralNetworkParameters
 ```@docs
 NetworkParameters
 params
+ParameterSet
 ```
 
 `NetworkParameters{T}` wraps a `NamedTuple` and forwards `getproperty`, `getindex`, `keys`, `values`,

--- a/scripts/wide_branch_cost.jl
+++ b/scripts/wide_branch_cost.jl
@@ -20,7 +20,6 @@
 # calls `flatten` at all comes from the second form.
 
 using NeuralNetworkParameters
-using NeuralNetworkParameters: mapparameters
 
 const T = Float32
 
@@ -37,8 +36,8 @@ function first_call(f, args...)
     round(time() - t; digits = 2)
 end
 
-# From inside a function, for the reason `test/flatten_tests.jl` gives: at the top level the walk is not
-# specialised and the figure is the harness's rather than the code's.
+# From inside a function, for the reason `test/flatten_tests.jl` gives: that is the claim that matters,
+# an optimizer's inner loop rather than the top level of a script.
 _flatten_allocs(buf, ps, layout) = @allocated flatten!(buf, ps, layout)
 _unflatten_allocs(dest, layout, v) = @allocated unflatten!(dest, layout, v)
 

--- a/scripts/wide_branch_cost.jl
+++ b/scripts/wide_branch_cost.jl
@@ -35,9 +35,19 @@ wide_set(k::Integer) = NamedTuple{Tuple(Symbol("p", i) for i in 1:k)}(
 
 # `time()` and not `@elapsed`: the point is the very first call, and `@elapsed` in a loop reports the
 # second.
+#
+# **`invokelatest` and not a direct `f(args...)`, and that is the whole measurement rather than a
+# detail.** Compiling `first_call` itself infers through the call in its body — so with a direct call the
+# 1.6 s of inference that `parameterlayout` on a 369-child branch costs is spent while `first_call` is
+# being compiled, *before* `t = time()` ever runs, and the figure printed is 0.00 s. This script read
+# 0.00 s for every width and every column on Julia 1.13 until it was written this way. `invokelatest`
+# makes the call opaque, so there is nothing left for the caller's own compilation to do first.
+#
+# That is the same lesson as the one-process-per-width fix below, from the other end: the harness has to
+# be arranged so that the cost cannot have been paid somewhere the clock is not looking.
 function first_call(f, args...)
     t = time()
-    f(args...)
+    Base.invokelatest(f, args...)
     round(time() - t; digits = 2)
 end
 
@@ -46,6 +56,18 @@ end
 _flatten_allocs(buf, ps, layout) = @allocated flatten!(buf, ps, layout)
 _unflatten_allocs(dest, layout, v) = @allocated unflatten!(dest, layout, v)
 
+# `mapparameters!` needs a **zero-argument** closure and not the two above. `@allocated f(a, b)` lowers
+# to `Base.allocated(f, a, b)`, and `mapparameters!` is a `Vararg` method — so the splat inside
+# `Base.allocated` allocates on its own account, which both invents bytes the walk does not spend and
+# hides the ones it does. `flatten!` is not a `Vararg` method, which is why the two above can be written
+# the obvious way. A thunk has nothing to splat.
+_thunk_allocs(thunk) = (thunk(); thunk(); @allocated thunk())
+
+# A destination-and-source walk, which is what an optimizer's elementwise primitives are, and the third
+# thing this sweep is for: `mapparameters!` took a `values(...)` tuple per branch per argument until the
+# walks began indexing them in place.
+_touch!(d, s) = (@inbounds d[begin] = s[begin]; nothing)
+
 # 32 is where `Base` stops unrolling a tuple; 369 is the parameter set of the MNIST transformer in
 # `scripts/geometric_optimizers/mnist.jl` of GMLDatasets.jl, which is the width that made the defect
 # worth fixing rather than noting.
@@ -53,7 +75,7 @@ const WIDTHS = (16, 32, 48, 64, 128, 369)
 
 header() = println(rpad("children", 10), rpad("layout", 9), rpad("map(zero)", 11),
                    rpad("mapparams", 11), rpad("flatten", 9), rpad("unflatten", 11),
-                   "allocs flatten!/unflatten!")
+                   "allocs flatten!/unflatten!/mapparameters!")
 
 # One width, in a process that has compiled nothing for it. Within the row the order still matters —
 # `flatten` builds a layout and would absorb `parameterlayout`, and `mapparameters` would absorb the
@@ -74,9 +96,10 @@ function sweep_one(k)
     _unflatten_allocs(dest, layout, v)
     a_flat = _flatten_allocs(buf, ps, layout)
     a_unflat = _unflatten_allocs(dest, layout, v)
+    a_mapp = _thunk_allocs(() -> mapparameters!(_touch!, dest, ps))
 
     println(rpad(k, 10), rpad(t_layout, 9), rpad(t_map, 11), rpad(t_mapp, 11),
-            rpad(t_flat, 9), rpad(t_unflat, 11), a_flat, "/", a_unflat)
+            rpad(t_flat, 9), rpad(t_unflat, 11), a_flat, "/", a_unflat, "/", a_mapp)
     flush(stdout)
 end
 

--- a/scripts/wide_branch_cost.jl
+++ b/scripts/wide_branch_cost.jl
@@ -2,8 +2,7 @@
 #
 # Run with the repository as the active project:
 #
-#     julia --project=. scripts/wide_branch_cost.jl              # the width sweep
-#     julia --project=. scripts/wide_branch_cost.jl --cold-map    # `mapparameters` in a fresh session
+#     julia --project=. scripts/wide_branch_cost.jl
 #
 # This is the harness behind the two tables in the 0.2.2 CHANGELOG entry, committed because a number
 # is reproducible only where the code that produced it is. It reports *first-call* time, which is
@@ -14,10 +13,16 @@
 # child by retyping the tuple — which `Base.tail` does. The point of the sweep is that the exponent is
 # visible: doubling the width used to multiply `flatten`'s compile time by about eight.
 #
-# The order of the calls matters and is why `--cold-map` exists. A `flatten` that has already compiled
-# for a given branch shape leaves much less for `mapparameters` to do at the same shape, so the
-# `mapparameters` column below is measured *before* `flatten`, and the figure for a session that never
-# calls `flatten` at all comes from the second form.
+# **Every width runs in a process of its own**, and that is the methodology rather than a detail.
+# Compilation is shared across a session, so a `flatten` that has already compiled for one branch shape
+# leaves less for `mapparameters` to do at the same shape — and a sweep that walks the widths in one
+# process is measuring, from the second row on, what the first row already paid for.
+#
+# This script used to do exactly that, with a `--cold-map` flag to recover the honest figure on demand.
+# The flag was the tell: a number you have to remember to ask for in a special way is a number the
+# default run is getting wrong. `GeometricOptimizers` quoted the default one — `mapparameters` at
+# "0.00 s" on a 369-entry branch, against 1.51 s measured cold — and closed an issue on it. A table is
+# cold here or it is not printed.
 
 using NeuralNetworkParameters
 
@@ -46,43 +51,42 @@ _unflatten_allocs(dest, layout, v) = @allocated unflatten!(dest, layout, v)
 # worth fixing rather than noting.
 const WIDTHS = (16, 32, 48, 64, 128, 369)
 
-function sweep()
-    println(rpad("children", 10), rpad("layout", 9), rpad("map(zero)", 11),
-            rpad("mapparams", 11), rpad("flatten", 9), rpad("unflatten", 11),
-            "allocs flatten!/unflatten!")
+header() = println(rpad("children", 10), rpad("layout", 9), rpad("map(zero)", 11),
+                   rpad("mapparams", 11), rpad("flatten", 9), rpad("unflatten", 11),
+                   "allocs flatten!/unflatten!")
+
+# One width, in a process that has compiled nothing for it. Within the row the order still matters —
+# `flatten` builds a layout and would absorb `parameterlayout`, and `mapparameters` would absorb the
+# rest — so the rows are ordered cheapest-first and `flatten` comes after both.
+function sweep_one(k)
+    ps = wide_set(k)
+    t_layout = first_call(parameterlayout, ps)
+    t_map = first_call(x -> map(zero, x), ps)
+    t_mapp = first_call(x -> mapparameters(zero, x), ps)
+    t_flat = first_call(flatten, ps)
+
+    v, layout = flatten(ps)
+    t_unflat = first_call(x -> unflatten(layout, x), v)
+
+    buf = similar(v)
+    dest = unflatten(layout, zero(v))
+    _flatten_allocs(buf, ps, layout)          # warm the call and the measurement
+    _unflatten_allocs(dest, layout, v)
+    a_flat = _flatten_allocs(buf, ps, layout)
+    a_unflat = _unflatten_allocs(dest, layout, v)
+
+    println(rpad(k, 10), rpad(t_layout, 9), rpad(t_map, 11), rpad(t_mapp, 11),
+            rpad(t_flat, 9), rpad(t_unflat, 11), a_flat, "/", a_unflat)
+    flush(stdout)
+end
+
+# `--in-process k` is what the child processes are invoked with, and is not for interactive use.
+function fan_out()
+    header()
     for k in WIDTHS
-        ps = wide_set(k)
-        t_layout = first_call(parameterlayout, ps)
-        t_map = first_call(x -> map(zero, x), ps)
-        t_mapp = first_call(x -> mapparameters(zero, x), ps)
-        t_flat = first_call(flatten, ps)
-
-        v, layout = flatten(ps)
-        t_unflat = first_call(x -> unflatten(layout, x), v)
-
-        buf = similar(v)
-        dest = unflatten(layout, zero(v))
-        _flatten_allocs(buf, ps, layout)          # warm the call and the measurement
-        _unflatten_allocs(dest, layout, v)
-        a_flat = _flatten_allocs(buf, ps, layout)
-        a_unflat = _unflatten_allocs(dest, layout, v)
-
-        println(rpad(k, 10), rpad(t_layout, 9), rpad(t_map, 11), rpad(t_mapp, 11),
-                rpad(t_flat, 9), rpad(t_unflat, 11), a_flat, "/", a_unflat)
-        flush(stdout)
+        run(pipeline(`$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project())
+                      $(@__FILE__) --in-process $k`))
     end
 end
 
-# `mapparameters` on a wide branch in a session that has compiled nothing else for that shape. This is
-# the figure to quote when asking what the walk costs on its own.
-function cold_map()
-    println(rpad("children", 10), rpad("map(zero)", 11), "mapparameters(zero)")
-    for k in WIDTHS
-        ps = wide_set(k)
-        println(rpad(k, 10), rpad(first_call(x -> map(zero, x), ps), 11),
-                first_call(x -> mapparameters(zero, x), ps))
-        flush(stdout)
-    end
-end
-
-"--cold-map" in ARGS ? cold_map() : sweep()
+"--in-process" in ARGS ? sweep_one(parse(Int, ARGS[findfirst(==("--in-process"), ARGS) + 1])) : fan_out()

--- a/scripts/wide_branch_cost.jl
+++ b/scripts/wide_branch_cost.jl
@@ -1,0 +1,89 @@
+# What the walks cost as a function of the *width* of one branch.
+#
+# Run with the repository as the active project:
+#
+#     julia --project=. scripts/wide_branch_cost.jl              # the width sweep
+#     julia --project=. scripts/wide_branch_cost.jl --cold-map    # `mapparameters` in a fresh session
+#
+# This is the harness behind the two tables in the 0.2.2 CHANGELOG entry, committed because a number
+# is reproducible only where the code that produced it is. It reports *first-call* time, which is
+# compilation plus a negligible run, and allocations on the second call from inside a function.
+#
+# The walk down a parameter tree is ordinary dispatch and has never been the cost. The walk across the
+# children of one branch is, and it is superlinear in the width for any recursion that reaches the next
+# child by retyping the tuple — which `Base.tail` does. The point of the sweep is that the exponent is
+# visible: doubling the width used to multiply `flatten`'s compile time by about eight.
+#
+# The order of the calls matters and is why `--cold-map` exists. A `flatten` that has already compiled
+# for a given branch shape leaves much less for `mapparameters` to do at the same shape, so the
+# `mapparameters` column below is measured *before* `flatten`, and the figure for a session that never
+# calls `flatten` at all comes from the second form.
+
+using NeuralNetworkParameters
+using NeuralNetworkParameters: mapparameters
+
+const T = Float32
+
+# All leaves the same tiny matrix: this measures the shape of the branch, not the size of the arrays
+# in it, and a 2×2 keeps the run time next to nothing beside the compilation.
+wide_set(k::Integer) = NamedTuple{Tuple(Symbol("p", i) for i in 1:k)}(
+    Tuple(fill(T(i), 2, 2) for i in 1:k))
+
+# `time()` and not `@elapsed`: the point is the very first call, and `@elapsed` in a loop reports the
+# second.
+function first_call(f, args...)
+    t = time()
+    f(args...)
+    round(time() - t; digits = 2)
+end
+
+# From inside a function, for the reason `test/flatten_tests.jl` gives: at the top level the walk is not
+# specialised and the figure is the harness's rather than the code's.
+_flatten_allocs(buf, ps, layout) = @allocated flatten!(buf, ps, layout)
+_unflatten_allocs(dest, layout, v) = @allocated unflatten!(dest, layout, v)
+
+# 32 is where `Base` stops unrolling a tuple; 369 is the parameter set of the MNIST transformer in
+# `scripts/geometric_optimizers/mnist.jl` of GMLDatasets.jl, which is the width that made the defect
+# worth fixing rather than noting.
+const WIDTHS = (16, 32, 48, 64, 128, 369)
+
+function sweep()
+    println(rpad("children", 10), rpad("layout", 9), rpad("map(zero)", 11),
+            rpad("mapparams", 11), rpad("flatten", 9), rpad("unflatten", 11),
+            "allocs flatten!/unflatten!")
+    for k in WIDTHS
+        ps = wide_set(k)
+        t_layout = first_call(parameterlayout, ps)
+        t_map = first_call(x -> map(zero, x), ps)
+        t_mapp = first_call(x -> mapparameters(zero, x), ps)
+        t_flat = first_call(flatten, ps)
+
+        v, layout = flatten(ps)
+        t_unflat = first_call(x -> unflatten(layout, x), v)
+
+        buf = similar(v)
+        dest = unflatten(layout, zero(v))
+        _flatten_allocs(buf, ps, layout)          # warm the call and the measurement
+        _unflatten_allocs(dest, layout, v)
+        a_flat = _flatten_allocs(buf, ps, layout)
+        a_unflat = _unflatten_allocs(dest, layout, v)
+
+        println(rpad(k, 10), rpad(t_layout, 9), rpad(t_map, 11), rpad(t_mapp, 11),
+                rpad(t_flat, 9), rpad(t_unflat, 11), a_flat, "/", a_unflat)
+        flush(stdout)
+    end
+end
+
+# `mapparameters` on a wide branch in a session that has compiled nothing else for that shape. This is
+# the figure to quote when asking what the walk costs on its own.
+function cold_map()
+    println(rpad("children", 10), rpad("map(zero)", 11), "mapparameters(zero)")
+    for k in WIDTHS
+        ps = wide_set(k)
+        println(rpad(k, 10), rpad(first_call(x -> map(zero, x), ps), 11),
+                first_call(x -> mapparameters(zero, x), ps))
+        flush(stdout)
+    end
+end
+
+"--cold-map" in ARGS ? cold_map() : sweep()

--- a/src/NeuralNetworkParameters.jl
+++ b/src/NeuralNetworkParameters.jl
@@ -30,7 +30,7 @@ module NeuralNetworkParameters
 
 using ChainRulesCore
 
-export NetworkParameters, params
+export NetworkParameters, params, ParameterSet
 
 include("parameters.jl")
 

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -71,7 +71,7 @@ end
 
 function _accumulate!(Δv, l::NestedLayout, Δ)
     Δ === nothing && return Δv
-    _accumulate_named!(Δv, values(l.children), keys(l.children), _cotangent_backing(Δ))
+    _accumulate_named!(Δv, l.children, _cotangent_backing(Δ))
     Δv
 end
 
@@ -92,15 +92,24 @@ function _accumulate!(Δv, l::LeafLayout, Δ)
     Δv
 end
 
-# The branch walks, in the `Base.tail` shape the rest of the package walks a layout in. A `for` loop
-# over `keys(l.children)` reads the same, but it indexes a heterogeneous `NamedTuple` with a runtime
-# `Symbol`: the child layout comes back as the union of the branch's child types, so `_accumulate!` is
-# dispatched dynamically once per child on every reverse pass. The keys are a compile-time constant
-# and the recursion keeps them one, which is the same reason `_unflatten_children` exists.
-@inline _accumulate_named!(Δv, ::Tuple{}, ::Tuple{}, Δ) = nothing
-@inline function _accumulate_named!(Δv, ls::Tuple, ks::Tuple, Δ)
-    _accumulate!(Δv, first(ls), _normalized(_cotangent_get(Δ, first(ks))))
-    _accumulate_named!(Δv, Base.tail(ls), Base.tail(ks), Δ)
+# The named branch walk, written out for the reason the head of `walk.jl` gives. A `for` loop over
+# `keys(l.children)` reads the same, but it indexes a heterogeneous `NamedTuple` with a runtime
+# `Symbol`: the child layout comes back as the union of the branch's child types, so `_accumulate!`
+# would be dispatched dynamically once per child on every reverse pass. Splicing the keys in as
+# literals keeps every one of them constant, and keeps the branch to one specialisation rather than one
+# per child.
+#
+# This is the reverse pass of a branch that can be as wide as a network has layers, so it is the one
+# walk here that had to be rewritten. The two positional walks below are not: their length is the
+# number of *blocks of a single leaf* — two for a `StiefelLieAlgHorMatrix`, one for a Grassmann lift —
+# so they stay the chain they read best as.
+@generated function _accumulate_named!(Δv, children::NamedTuple{Keys}, Δ) where {Keys}
+    calls = [:(_accumulate!(Δv, getfield(children, $i),
+                            _normalized(_cotangent_get(Δ, $(QuoteNode(Keys[i])))))) for i in 1:length(Keys)]
+    quote
+        $(calls...)
+        nothing
+    end
 end
 
 # The positional walk consumes the cotangent alongside the layout rather than indexing into it, so it
@@ -182,17 +191,21 @@ function _storage_field(prototype, storage)
     nothing
 end
 
-# `freeparameters` of the prototype tells us which of the tangent's fields are the storage. Both cases
-# recurse rather than closing over `nt`, for the reason `_unflatten_children` does — and the positional
-# one used to be an `ntuple` over a *runtime* length, which stops being inferable past ten blocks.
+# `freeparameters` of the prototype tells us which of the tangent's fields are the storage. Neither
+# case closes over `nt`, for the reason `_unflatten_children` does not — and the positional one used to
+# be an `ntuple` over a *runtime* length, which stops being inferable past ten blocks.
+#
+# Both walk the storage of *one leaf*, so neither is wide the way a branch of layers is; the named one
+# is written out all the same, because splicing the keys in as literals is what keeps
+# `_cotangent_get`'s `haskey` a compile-time question.
 _matching_storage(storage::NamedTuple, nt::NamedTuple) =
-    NamedTuple{keys(storage)}(_matching_named(keys(storage), nt))
+    NamedTuple{keys(storage)}(_matching_named(storage, nt))
 _matching_storage(storage::Tuple, nt::NamedTuple) = _matching_positional(storage, values(nt))
 _matching_storage(_, nt::NamedTuple) = nt
 
-@inline _matching_named(::Tuple{}, _) = ()
-@inline _matching_named(ks::Tuple, nt) =
-    (_cotangent_get(nt, first(ks)), _matching_named(Base.tail(ks), nt)...)
+@generated function _matching_named(storage::NamedTuple{Keys}, nt) where {Keys}
+    :(($((:(_cotangent_get(nt, $(QuoteNode(k)))) for k in Keys)...),))
+end
 
 @inline _matching_positional(::Tuple{}, _) = ()
 @inline _matching_positional(storage::Tuple, Δ) =

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -123,13 +123,13 @@ end
 
 _add_leaf_cotangent!(Δv, l::LeafLayout, Δ::Number) = (Δv[first(l.range)] += Δ; nothing)
 
+# Broadcast over the leaf's stretch of the flat vector and not a loop over its elements, for the reason
+# `flatten` copies with `copyto!`: an element of a leaf is never indexed individually, so the reverse
+# pass reaches a GPU array on the same terms the forward one does.
 function _add_leaf_cotangent!(Δv, l::LeafLayout, Δ::AbstractArray)
     length(Δ) == length(l.range) || throw(DimensionMismatch(string(
         "cotangent of length ", length(Δ), " for a leaf of length ", length(l.range))))
-    o = first(l.range) - 1
-    for (i, x) in enumerate(Δ)
-        Δv[o + i] += x
-    end
+    @views Δv[l.range] .+= vec(Δ)
     nothing
 end
 

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -101,7 +101,7 @@ function flatten!(v::AbstractVector, ps, layout::ParameterLayout)
 end
 
 @inline _flatten!(v, ps::NetworkParameters, l::ParametersLayout) = _flatten!(v, params(ps), l.inner)
-@inline _flatten!(v, ps::NamedTuple, l::NestedLayout) = _flatten_children!(v, values(ps), values(l.children))
+@inline _flatten!(v, ps::NamedTuple, l::NestedLayout) = _flatten_children!(v, ps, l.children)
 @inline _flatten!(v, ps::Tuple, l::TupleLayout) = _flatten_children!(v, ps, l.children)
 @inline _flatten!(v, x, l::WrappedLayout) = _flatten!(v, freeparameters(x), l.inner)
 
@@ -110,10 +110,16 @@ end
     nothing
 end
 
-@inline _flatten_children!(v, ::Tuple{}, ::Tuple{}) = nothing
-@inline function _flatten_children!(v, xs::Tuple, ls::Tuple)
-    _flatten!(v, first(xs), first(ls))
-    _flatten_children!(v, Base.tail(xs), Base.tail(ls))
+# `getfield` and not `values(·)[i]`: taking `values` of a branch first materialises a temporary tuple
+# per branch, which at 64 children is where the last of the allocations were. `getfield(·, i)` reads
+# the child in place and serves a `NamedTuple` and a `Tuple` alike.
+@generated function _flatten_children!(v, xs, ls)
+    n = _children_arity(xs, ls)
+    calls = [:(_flatten!(v, getfield(xs, $i), getfield(ls, $i))) for i in 1:n]
+    quote
+        $(calls...)
+        nothing
+    end
 end
 
 @inline _copy_out!(v, doffs::Int, x::AbstractArray, n::Int) = (
@@ -155,7 +161,7 @@ cannot alias each other or the flat vector.
 """
 @inline unflatten(l::ParametersLayout, v::AbstractVector) = NetworkParameters(unflatten(l.inner, v))
 @inline unflatten(l::NestedLayout, v::AbstractVector) =
-    NamedTuple{keys(l.children)}(_unflatten_children(values(l.children), v))
+    NamedTuple{keys(l.children)}(_unflatten_children(l.children, v))
 @inline unflatten(l::TupleLayout, v::AbstractVector) = _unflatten_children(l.children, v)
 @inline unflatten(l::WrappedLayout, v::AbstractVector) = rebuild(l.prototype, unflatten(l.inner, v))
 @inline unflatten(l::LeafLayout, v::AbstractVector) = _reshape_leaf(v[l.range], l.size)
@@ -174,7 +180,7 @@ are *not* rebuilt: a block of a Jacobian is not a parameter, so there is nothing
 """
 @inline unflatten(l::ParametersLayout, J::AbstractMatrix) = NetworkParameters(unflatten(l.inner, J))
 @inline unflatten(l::NestedLayout, J::AbstractMatrix) =
-    NamedTuple{keys(l.children)}(_unflatten_children(values(l.children), J))
+    NamedTuple{keys(l.children)}(_unflatten_children(l.children, J))
 @inline unflatten(l::TupleLayout, J::AbstractMatrix) = _unflatten_children(l.children, J)
 @inline unflatten(l::WrappedLayout, J::AbstractMatrix) = unflatten(l.inner, J)
 @inline unflatten(l::LeafLayout, J::AbstractMatrix) = J[l.range, :]
@@ -190,9 +196,10 @@ are *not* rebuilt: a block of a Jacobian is not a parameter, so there is nothing
 #
 # `data` is the flat vector or the Jacobian; which of the two decides the `unflatten` method, so one
 # helper serves both.
-@inline _unflatten_children(::Tuple{}, _) = ()
-@inline _unflatten_children(layouts::Tuple, data) =
-    (unflatten(first(layouts), data), _unflatten_children(Base.tail(layouts), data)...)
+@generated function _unflatten_children(layouts, data)
+    calls = [:(unflatten(getfield(layouts, $i), data)) for i in 1:fieldcount(layouts)]
+    :(($(calls...),))
+end
 
 """
     unflatten!(ps, layout, v)
@@ -217,7 +224,7 @@ end
 
 @inline _unflatten!(ps::NetworkParameters, l::ParametersLayout, v) = _unflatten!(params(ps), l.inner, v)
 @inline _unflatten!(ps::NamedTuple, l::NestedLayout, v) = _unflatten_children!(
-    values(ps), values(l.children), v)
+    ps, l.children, v)
 @inline _unflatten!(ps::Tuple, l::TupleLayout, v) = _unflatten_children!(ps, l.children, v)
 @inline _unflatten!(x, l::WrappedLayout, v) = _unflatten!(freeparameters(x), l.inner, v)
 
@@ -231,8 +238,11 @@ function _unflatten!(x::Number, ::LeafLayout, _)
         "`; use the out-of-place `unflatten` for a parameter set with scalar leaves")))
 end
 
-@inline _unflatten_children!(::Tuple{}, ::Tuple{}, v) = nothing
-@inline function _unflatten_children!(xs::Tuple, ls::Tuple, v)
-    _unflatten!(first(xs), first(ls), v)
-    _unflatten_children!(Base.tail(xs), Base.tail(ls), v)
+@generated function _unflatten_children!(xs, ls, v)
+    n = _children_arity(xs, ls)
+    calls = [:(_unflatten!(getfield(xs, $i), getfield(ls, $i), v)) for i in 1:n]
+    quote
+        $(calls...)
+        nothing
+    end
 end

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -79,10 +79,8 @@ end
 
 Write the numbers of `ps` into the existing vector `v`, and return `v`.
 
-Allocation-free when the `layout` is supplied and the call is made from compiled code, which is the
-point: an optimizer that flattens its parameters once per step, or twice per inner product, should not
-allocate a fresh vector each time. (Called from an uninferred context — the top level of a script, say —
-the recursion is not specialised and costs a few tens of bytes per leaf on Julia 1.10.)
+Allocation-free when the `layout` is supplied, which is the point: an optimizer that flattens its
+parameters once per step, or twice per inner product, should not allocate a fresh vector each time.
 
 ```julia
 v, layout = flatten(ps)          # once
@@ -185,14 +183,12 @@ are *not* rebuilt: a block of a Jacobian is not a parameter, so there is nothing
 @inline unflatten(l::WrappedLayout, J::AbstractMatrix) = unflatten(l.inner, J)
 @inline unflatten(l::LeafLayout, J::AbstractMatrix) = J[l.range, :]
 
-# `unflatten` over the children of a branch layout, in the shape the rest of this package walks a
-# layout tree: `Base.tail` recursion, inlined, rather than `map` over a closure.
+# `unflatten` over the children of a branch layout, written out for the reason the head of `walk.jl`
+# gives rather than written as `map` over a closure.
 #
-# The two are equally inferable, but `map` leaves the closure over `data` to be elided and not every
-# version elides it. On Julia 1.11 the recursion halves what an `unflatten` call costs, from two heap
-# allocations per leaf to one; on 1.10 it is worth as much again on some shapes and nothing on others.
-# It also keeps the walk off `Base`'s `Any32` fallback, which `map` drops to past 32 children and
-# which returns a tuple with no concrete type.
+# The two are equally inferable, but `map` leaves the closure over `data` to be elided, and past 32
+# children it drops to `Base`'s `Any32` fallback, which returns a tuple with no concrete type. A
+# written-out body leaves no closure to elide and reaches no fallback, at any width.
 #
 # `data` is the flat vector or the Jacobian; which of the two decides the `unflatten` method, so one
 # helper serves both.

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -112,7 +112,7 @@ end
 # per branch, which at 64 children is where the last of the allocations were. `getfield(·, i)` reads
 # the child in place and serves a `NamedTuple` and a `Tuple` alike.
 @generated function _flatten_children!(v, xs, ls)
-    n = _children_arity(xs, ls)
+    n = _children_arity(xs, (ls,))
     calls = [:(_flatten!(v, getfield(xs, $i), getfield(ls, $i))) for i in 1:n]
     quote
         $(calls...)
@@ -235,7 +235,7 @@ function _unflatten!(x::Number, ::LeafLayout, _)
 end
 
 @generated function _unflatten_children!(xs, ls, v)
-    n = _children_arity(xs, ls)
+    n = _children_arity(xs, (ls,))
     calls = [:(_unflatten!(getfield(xs, $i), getfield(ls, $i), v)) for i in 1:n]
     quote
         $(calls...)

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -127,45 +127,97 @@ function _layout(ps::NetworkParameters, offset::Int)
     ParametersLayout(inner), off
 end
 
-function _layout(ps::NamedTuple, offset::Int)
-    children, off = _layout_children(ps, offset)
-    NestedLayout(NamedTuple{keys(ps)}(children), (offset + 1):off), off
-end
-
-function _layout(ps::Tuple, offset::Int)
-    children, off = _layout_children(ps, offset)
-    TupleLayout(children, (offset + 1):off), off
-end
-
-function _layout(x, offset::Int)
-    s = freeparameters(x)
-    if s === x
-        n = length(x)
-        LeafLayout((offset + 1):(offset + n), _leafsize(x), x), offset + n
-    else
-        inner, off = _layout(s, offset)
-        WrappedLayout(x, inner), off
-    end
-end
-
-# Written out for the reason the head of `walk.jl` gives, and threading the offset left to right, as
-# the recursion this replaces did: the ranges a layout hands out are the order `flatten` writes in.
-# This one was never `@inline`d, so it was the cheapest of the walks to begin with -- 0.04 s where
-# `flatten` took 17.6 s at the same 128 children -- but it paid the same `k` specialisations, and it
-# is the only walk that runs even when nothing is flattened.
-@generated function _layout_children(xs, offset::Int)
-    n = fieldcount(xs)
-    n == 0 && return :(((), offset))
-    body = [:((child_1, off_1) = _layout(getfield(xs, 1), offset))]
+# The two branch cases, each **one** `@generated` body that lays the children out *and* builds the
+# layout around them.
+#
+# Splitting those two steps is what this used to do, and it is the expensive way round. A generated
+# body that returns a `k`-element tuple is cheap on its own — 1.27 s at 369 children — and so is
+# wrapping a tuple you already hold in a `NamedTuple` and a struct — 0.13 s. Composing them across a
+# function call is neither: inference has to carry the whole 369-element tuple type from the callee
+# into the caller's own inference, and `parameterlayout` on that set cost **11.7 s**, of which
+# the child walk alone was 0.49 s of it and the wrapping was the rest. Fused into one body, and with
+# the leaf union below removed, it is **1.36 s**.
+#
+# Measured every way round before settling on this. A `@noinline` barrier on the child walk does not
+# help (11.78 s). Neither does supplying `NestedLayout`'s type parameters instead of letting them be
+# solved. And computing the child lengths first so that the children could be laid out *independently*
+# — the obvious way to break the serial offset dependency — is **worse**, 15.4 s, because it adds two
+# more `k`-long bodies to pay for; the serial dependency was never the cost, as an "every child at the
+# same offset" control shows at 1.17 s against the real walk's 1.27 s.
+#
+# The offset threads left to right, as the recursion this replaces did: the ranges a layout hands out
+# are the order `flatten` writes in.
+@generated function _layout(ps::NamedTuple{Keys}, offset::Int) where {Keys}
+    n = length(Keys)
+    n == 0 && return :((NestedLayout(NamedTuple{$Keys}(()), (offset + 1):offset), offset))
+    body = [:((child_1, off_1) = _layout(getfield(ps, 1), offset))]
     for i in 2:n
         push!(body, :(($(Symbol(:child_, i)), $(Symbol(:off_, i))) =
-            _layout(getfield(xs, $i), $(Symbol(:off_, i - 1)))))
+            _layout(getfield(ps, $i), $(Symbol(:off_, i - 1)))))
     end
     children = Expr(:tuple, (Symbol(:child_, i) for i in 1:n)...)
+    final = Symbol(:off_, n)
     quote
         $(body...)
-        $children, $(Symbol(:off_, n))
+        NestedLayout(NamedTuple{$Keys}($children), (offset + 1):$final), $final
     end
+end
+
+@generated function _layout(ps::Tuple, offset::Int)
+    n = fieldcount(ps)
+    n == 0 && return :((TupleLayout((), (offset + 1):offset), offset))
+    body = [:((child_1, off_1) = _layout(getfield(ps, 1), offset))]
+    for i in 2:n
+        push!(body, :(($(Symbol(:child_, i)), $(Symbol(:off_, i))) =
+            _layout(getfield(ps, $i), $(Symbol(:off_, i - 1)))))
+    end
+    children = Expr(:tuple, (Symbol(:child_, i) for i in 1:n)...)
+    final = Symbol(:off_, n)
+    quote
+        $(body...)
+        TupleLayout($children, (offset + 1):$final), $final
+    end
+end
+
+# A leaf, terminal or wrapped, decided by **dispatch on the storage's type** rather than by an `if`
+# on `freeparameters(x) === x`.
+#
+# The identity test is the right *question* — it is what `isterminal` asks — and asking it inside one
+# method body was measurably the wrong way to ask it. Inference could not fold the branch, so
+# `_layout` on a plain `Matrix{Float32}` came back as a **three-way union**: a `LeafLayout`, and two
+# shapes of `WrappedLayout`. One union per child is survivable; a branch of 369 children each of a
+# three-way union is not, and it is what made `parameterlayout` cost 11.7 s on the flat parameter set
+# of GMLDatasets' MNIST transformer.
+#
+# Splitting on `::T`/`::T` puts the question to the method table, where it is answered once per leaf
+# type at compile time. Keeping the `===` *inside* the same-type method does not work and was tried:
+# inference cannot prove that two arguments are the same object, so the union came straight back. The
+# identity has to be decided by dispatch or not at all.
+#
+# What that gives up is a leaf whose `freeparameters` returns a *distinct object of its own type*,
+# which this now treats as terminal where the `===` would have wrapped it. Nothing is lost, because
+# such a type never worked: `_layout` would descend into the storage, ask it for *its*
+# `freeparameters`, and recurse without end unless it eventually changed type. A leaf either hands
+# back itself or hands back something else.
+#
+# [`isterminal`](@ref) still asks the identity question, and is still right to — it is a predicate a
+# caller evaluates on a value it holds, not a dispatch this has to infer through.
+@inline _layout(x, offset::Int) = _layout_storage(x, freeparameters(x), offset)
+
+# same type: terminal, the numbers are copied straight out of `x`
+@inline _layout_storage(x::T, ::T, offset::Int) where {T} = _leaf_layout(x, offset)
+
+# different type: the storage is structured, so lay it out and rebuild around it
+@inline _layout_storage(x, s, offset::Int) = _wrapped_layout(x, s, offset)
+
+@inline function _leaf_layout(x, offset::Int)
+    n = length(x)
+    LeafLayout((offset + 1):(offset + n), _leafsize(x), x), offset + n
+end
+
+@inline function _wrapped_layout(x, s, offset::Int)
+    inner, off = _layout(s, offset)
+    WrappedLayout(x, inner), off
 end
 
 _leafsize(x::AbstractArray) = size(x)

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -128,7 +128,7 @@ function _layout(ps::NetworkParameters, offset::Int)
 end
 
 function _layout(ps::NamedTuple, offset::Int)
-    children, off = _layout_children(values(ps), offset)
+    children, off = _layout_children(ps, offset)
     NestedLayout(NamedTuple{keys(ps)}(children), (offset + 1):off), off
 end
 
@@ -148,12 +148,24 @@ function _layout(x, offset::Int)
     end
 end
 
-_layout_children(::Tuple{}, offset::Int) = ((), offset)
-
-function _layout_children(xs::Tuple, offset::Int)
-    child, off = _layout(first(xs), offset)
-    rest, final = _layout_children(Base.tail(xs), off)
-    (child, rest...), final
+# Written out for the reason the head of `walk.jl` gives, and threading the offset left to right, as
+# the recursion this replaces did: the ranges a layout hands out are the order `flatten` writes in.
+# This one was never `@inline`d, so it was the cheapest of the walks to begin with -- 0.04 s where
+# `flatten` took 17.6 s at the same 128 children -- but it paid the same `k` specialisations, and it
+# is the only walk that runs even when nothing is flattened.
+@generated function _layout_children(xs, offset::Int)
+    n = fieldcount(xs)
+    n == 0 && return :(((), offset))
+    body = [:((child_1, off_1) = _layout(getfield(xs, 1), offset))]
+    for i in 2:n
+        push!(body, :(($(Symbol(:child_, i)), $(Symbol(:off_, i))) =
+            _layout(getfield(xs, $i), $(Symbol(:off_, i - 1)))))
+    end
+    children = Expr(:tuple, (Symbol(:child_, i) for i in 1:n)...)
+    quote
+        $(body...)
+        $children, $(Symbol(:off_, n))
+    end
 end
 
 _leafsize(x::AbstractArray) = size(x)

--- a/src/leaves.jl
+++ b/src/leaves.jl
@@ -201,7 +201,13 @@ end
 # without it `flatten` raises rather than guessing an element type for numbers it can see.
 @inline parameter_eltype(x) = Union{}
 
-@inline _promote_eltypes(::Tuple{}) = Union{}
-@inline function _promote_eltypes(xs::Tuple)
-    promote_type(parameter_eltype(first(xs)), _promote_eltypes(Base.tail(xs)))
+# Written out rather than recursed for the reason the head of `walk.jl` gives: a `Base.tail` chain
+# costs one specialisation per child, and this one is on `flatten`'s path.
+@generated function _promote_eltypes(xs::Tuple)
+    fieldcount(xs) == 0 && return :(Union{})
+    expr = :(parameter_eltype(xs[1]))
+    for i in 2:fieldcount(xs)
+        expr = :(promote_type($expr, parameter_eltype(xs[$i])))
+    end
+    expr
 end

--- a/src/leaves.jl
+++ b/src/leaves.jl
@@ -205,9 +205,9 @@ end
 # costs one specialisation per child, and this one is on `flatten`'s path.
 @generated function _promote_eltypes(xs::Tuple)
     fieldcount(xs) == 0 && return :(Union{})
-    expr = :(parameter_eltype(xs[1]))
+    expr = :(parameter_eltype(getfield(xs, 1)))
     for i in 2:fieldcount(xs)
-        expr = :(promote_type($expr, parameter_eltype(xs[$i])))
+        expr = :(promote_type($expr, parameter_eltype(getfield(xs, $i))))
     end
     expr
 end

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -136,6 +136,57 @@ the short name.
 """
 params(p::NetworkParameters) = getfield(p, :params)
 
+"""
+    ParameterSet
+
+Either of the two forms a whole set of parameters arrives in: a [`NetworkParameters`](@ref), or the
+bare `NamedTuple` it wraps.
+
+This is the type to dispatch on when a method takes *the parameters* and does not care which of the
+two it was handed — a loss, a `changebackend`, a walk, an optimizer entry point. Every package in
+this ecosystem was spelling the union out inline, and `SymbolicNeuralNetworks` had named it
+`EquationSet` for the equation sets that share the shape; one name means a reader meets the same
+type everywhere.
+
+!!! note "Not the same question as `isparametertree`"
+    [`isparametertree`](@ref) is true for a `Tuple` as well, because a `Tuple` *is* a branch the
+    walks recurse into — it is what [`freeparameters`](@ref) returns for a multi-block leaf such as a
+    horizontal lift, and why [`TupleLayout`](@ref) exists. It is never a set of parameters handed in
+    whole, which is always keyed. So `x isa ParameterSet` and `isparametertree(x)` disagree on
+    exactly the `Tuple`s, and each is right for its own question.
+
+Note also what this does *not* say. It puts no bound on the element type and none on the depth: a
+`ParameterSet` may nest to any depth and its leaves need not share a type. A caller that needs "flat,
+and every leaf an `AbstractArray{T}`" wants a narrower type of its own —
+`GeometricOptimizers.ParameterContainer{T}` is one — and cannot get it from here.
+
+# Examples
+
+```jldoctest
+using NeuralNetworkParameters
+
+nt = (L1 = (W = [1.0 2.0], b = [3.0]),)
+(nt isa ParameterSet, NetworkParameters(nt) isa ParameterSet, nt.L1 isa ParameterSet)
+
+# output
+
+(true, true, true)
+```
+
+A leaf is not one, and neither is the `Tuple` a multi-block leaf is made of:
+
+```jldoctest
+using NeuralNetworkParameters
+
+([1.0, 2.0] isa ParameterSet, ([1.0], [2.0]) isa ParameterSet)
+
+# output
+
+(false, false)
+```
+"""
+const ParameterSet = Union{NetworkParameters, NamedTuple}
+
 # The `<:Any` is the element type, which comes first so that `NetworkParameters{T}` binds `T` in a
 # method signature — what `GeometricOptimizers` needs of a parameter set to take it as a solution.
 # These three are the only methods here that name a type parameter at all.

--- a/src/walk.jl
+++ b/src/walk.jl
@@ -23,10 +23,19 @@
 # shape slower still (3.2 s at 64) *and* costs 187 808 bytes, because the chain is what kept the
 # per-leaf `copyto!` statically dispatched.
 #
-# So `_children_across` writes the flat body out instead: one `@generated` expansion per branch shape,
-# `k` statements indexing `xs[1] … xs[k]` at *literal* indices. One specialisation instead of `k`, no
-# new tuple types at all, every index inferred at a constant, and the same straight-line code the
-# chain used to inline down to. See open issue D9 in the CHANGELOG for the numbers before and after.
+# So the across-children walks write the flat body out instead: one `@generated` expansion per branch
+# shape, `k` statements reading `getfield(xs, 1) … getfield(xs, k)` at *literal* indices. One
+# specialisation instead of `k`, no new tuple types at all, every index inferred at a constant, and
+# the same straight-line code the chain used to inline down to. They are `_foreach_zip`,
+# `_fold_children` and `_anynothing` here, `_flatten_children!`, `_unflatten_children` and
+# `_unflatten_children!` in `flatten.jl`, the two branch cases of `_layout` in `layout.jl`,
+# `_promote_eltypes` in
+# `leaves.jl`, and `_accumulate_named!` and `_matching_named` on the reverse pass in `derivatives.jl`.
+#
+# **Writing a body out is not free, and one walk here does not.** It costs compilation per branch
+# shape, and for a walk that runs once rather than once per iteration that is the wrong trade — see
+# `_map_zip`, which hands branches wider than 32 children back to `Base.map` and says why at length.
+# The distinction to apply is not "wide or narrow" but "in an inner loop or not".
 
 """
     mapparameters(f, ps)
@@ -252,6 +261,28 @@ end
 # helpers
 # ---------------------------------------------------------------------------------------------------
 
+# The arity check the `Base.tail` chains used to get for free, by running out of `Tuple{}` methods.
+# Raised from the generated bodies, so it is a clear error at specialisation time rather than a
+# `MethodError` naming a tuple type nobody wrote.
+#
+# **This has to be defined before every generated body that calls it, and that is not a matter of
+# taste.** A `@generated` function's generator runs in the world age of its own method definition, so
+# a helper defined further down the file is invisible to it: the generator raises
+# `MethodError: no method matching _children_arity(…)  The applicable method may be too new`. Loading
+# a precompiled package hides this, because deserialising the cache gives every method in the module
+# one world age -- so it is only seen when the sources are evaluated, which is what
+# `--compiled-modules=no` does and what `test/world_age_tests.jl` pins. `src/flatten.jl`'s two callers
+# are covered by `walk.jl` being included first.
+function _children_arity(xs, rest...)
+    n = fieldcount(xs)
+    for (j, r) in enumerate(rest)
+        fieldcount(r) == n || throw(ArgumentError(string(
+            "parameter sets walked together must have the same number of children at every level; ",
+            "got ", n, " and, in argument ", j + 1, ", ", fieldcount(r), ".")))
+    end
+    n
+end
+
 @inline _as_namedtuple(x::NetworkParameters) = params(x)
 @inline _as_namedtuple(x::NamedTuple) = x
 @inline _as_namedtuple(x::Nothing) = nothing
@@ -273,9 +304,56 @@ end
     foldr((a, b) -> :($a || $b), tests)
 end
 
-# One method for both arities: with no `rest` the inner splat is empty and this is the plain map.
-@generated function _map_zip(recurse, f, xs, rest...)
-    n = _children_arity(xs, rest...)
+# The out-of-place walk, and **the one walk here that hands wide branches back to `Base.map`.**
+#
+# Every other across-children walk in this package is written out at every width, and this one is not,
+# because what they need and what it needs are different things. `_flatten_children!`,
+# `_unflatten_children!` and `_foreach_zip` run once per optimizer *iteration* or more, and
+# `_unflatten_children` runs once per objective evaluation through the closure a `Gradient` is built
+# from; for those, type stability and zero allocation are the property the package exists to provide,
+# and they are worth any amount of compilation. `_map_zip` is what `mapparameters` and `mapstorage`
+# are, and a consumer calls those once per cache, once per `changebackend`, once per `map_to_cpu` —
+# not per iteration.
+#
+# The cost of writing it out is real and it is paid per (function, branch shape) pair. Measured cold on
+# a flat 369-entry set, Julia 1.11.9: `map(zero, ps)` compiles in 0.01 s and a written-out
+# `mapparameters(zero, ps)` in 1.51 s. `GeometricOptimizers` reaches six such primitives while building
+# one `OptimizerCache`, which took that from 1.57 s to **71.16 s** on the parameter set of GMLDatasets'
+# MNIST transformer — a shape a consumer really has.
+#
+# `Base.map` has no such cliff because past 32 fields it drops to the `Any32` loop, and that fallback
+# is exactly what it costs: inference gives up on the result, and it allocates about 30 % more than the
+# written-out body (19 824 bytes against 15 424 at 128 children). For a walk that runs once, that buys
+# one dynamic dispatch at the call site — the *object* it returns is concretely typed either way, so
+# everything downstream of it specialises normally. For a walk in an inner loop it would buy one per
+# call, which is why the split is here and not everywhere.
+#
+# So: written out to 32 children, `map` beyond. 32 and not another number because it is the width
+# `Base` itself unrolls a tuple to, so below the threshold nothing is given up and above it nothing is
+# gained. A network's layer is far below it; the flat set that made D12 a defect is far above.
+#
+# (The closure `map` is handed here used to be the objection to it, and is no longer. `map` over a
+# closure was reported not to be elided on Julia 1.10, which is why the walks in this package became
+# `Base.tail` chains in the first place. On 1.11, 1.12 and 1.13 alike a closure costs nothing against a
+# plain function — 6240 bytes against 6224 at 40 children, 19 824 against 19 808 at 128 — so that
+# reason expired with the 1.10 floor.)
+const _WRITE_OUT_MAX_CHILDREN = 32
+
+# The branch is on `fieldcount` of a *type*, so it folds to a constant and only one arm is compiled.
+# It is here rather than inside the `@generated` body below because a generated function may not emit
+# a closure — "The function body AST defined by this @generated function is not pure" — and the `map`
+# arm needs one.
+@inline function _map_zip(recurse, f, xs, rest::Vararg{Any, N}) where {N}
+    _children_arity(typeof(xs), map(typeof, rest)...)
+    if fieldcount(typeof(xs)) > _WRITE_OUT_MAX_CHILDREN
+        map((cs...) -> recurse(f, cs...), xs, rest...)
+    else
+        _map_zip_written(recurse, f, xs, rest...)
+    end
+end
+
+@generated function _map_zip_written(recurse, f, xs, rest...)
+    n = fieldcount(xs)
     calls = [Expr(:call, :recurse, :f, :(getfield(xs, $i)),
                   (:(getfield(rest[$j], $i)) for j in 1:length(rest))...) for i in 1:n]
     :(($(calls...),))
@@ -303,17 +381,4 @@ end
         throw(ArgumentError(string("parameter sets have different keys: ", ks, " and ", keys(other))))
     end
     _check_keys(ks, Base.tail(nts))
-end
-
-# The arity check the `Base.tail` chains used to get for free, by running out of `Tuple{}` methods.
-# Raised from the generated bodies, so it is a clear error at specialisation time rather than a
-# `MethodError` naming a tuple type nobody wrote.
-function _children_arity(xs, rest...)
-    n = fieldcount(xs)
-    for (j, r) in enumerate(rest)
-        fieldcount(r) == n || throw(ArgumentError(string(
-            "parameter sets walked together must have the same number of children at every level; ",
-            "got ", n, " and, in argument ", j + 1, ", ", fieldcount(r), ".")))
-    end
-    n
 end

--- a/src/walk.jl
+++ b/src/walk.jl
@@ -32,6 +32,14 @@
 # `_promote_eltypes` in
 # `leaves.jl`, and `_accumulate_named!` and `_matching_named` on the reverse pass in `derivatives.jl`.
 #
+# A walk that takes *several* sets in lockstep indexes each of them in place too, and that is the same
+# point made about the second argument. Taking `values` of a branch to zip it materialises a temporary
+# tuple per branch per argument, which is free while the branch stays in registers and is not beyond
+# that: `mapparameters!` on a flat 48-child set cost 800 bytes a call that way and 6 144 at 369, and a
+# branch of branches three to four times that. So `_foreach_zip` reads every one of its arguments with
+# `getfield` at a literal index, exactly as `_flatten_children!` reads the layout, and the arity and the
+# keys are checked in the generator where they cost nothing.
+#
 # **Writing a body out is not free, and one walk here does not.** It costs compilation per branch
 # shape, and for a walk that runs once rather than once per iteration that is the wrong trade — see
 # `_map_zip`, which hands branches wider than 32 children back to `Base.map` and says why at length.
@@ -86,7 +94,7 @@ mapparameters(+, a, c).L1.b
 @inline function mapparameters(f, ps::NamedTuple, rest::Vararg{Any, N}) where {N}
     nts = map(_as_namedtuple, rest)
     _check_keys(keys(ps), nts)
-    NamedTuple{keys(ps)}(_map_zip(mapparameters, f, ps, nts...))
+    _rewrap_children(ps, _map_zip(mapparameters, f, ps, nts...))
 end
 
 @inline mapparameters(f, ps::Tuple, rest::Vararg{Any, N}) where {N} = _map_zip(
@@ -126,7 +134,7 @@ mapstorage(x -> x ./ 2, ps).L1.W
 @inline function mapstorage(f, ps::NamedTuple, rest::Vararg{Any, N}) where {N}
     nts = map(_as_namedtuple, rest)
     _check_keys(keys(ps), nts)
-    NamedTuple{keys(ps)}(_map_zip(mapstorage, f, ps, nts...))
+    _rewrap_children(ps, _map_zip(mapstorage, f, ps, nts...))
 end
 
 @inline mapstorage(f, ps::Tuple, rest::Vararg{Any, N}) where {N} = _map_zip(
@@ -143,21 +151,27 @@ end
 
 Walk the leaves of `ps` for the side effect of `f`, in lockstep with `rest`. Returns `nothing`.
 
+The children of a keyed branch are paired **by key**, and the keys have to agree — a `rest` whose keys
+are the same set in a different order is an `ArgumentError` and not a silent crossing-over. A `Tuple`
+branch is paired positionally, since the blocks of a multi-block leaf have no keys to agree on.
+
 A branch or leaf of `rest` that is `nothing` **skips** that position entirely — `f` is not called
 there. This is what lets a gradient tree that is missing the entries of a frozen or non-trainable
 layer be walked against the parameters it belongs to, without having to fill the holes in first.
+
+Allocation-free, at any width of branch, any depth of nesting and any number of `rest`: the branches are
+indexed in place rather than taken apart, so nothing is materialised on the way in.
 
 See [`mapparameters!`](@ref) for the in-place variant that returns its destination.
 """
 @inline function foreachparameters(f, ps::Union{NetworkParameters, NamedTuple},
         rest::Vararg{Any, N}) where {N}
-    nt = _as_namedtuple(ps)
-    _foreach_zip(f, freeparameters, nt, map(r -> _values_for(r, keys(nt)), rest)...)
+    _foreach_zip(f, freeparameters, _as_namedtuple(ps), map(_as_namedtuple, rest)...)
     nothing
 end
 
 @inline function foreachparameters(f, ps::Tuple, rest::Vararg{Any, N}) where {N}
-    _foreach_zip(f, freeparameters, ps, map(r -> _tuple_for(r, length(ps)), rest)...)
+    _foreach_zip(f, freeparameters, ps, map(_as_tuple, rest)...)
     nothing
 end
 
@@ -173,7 +187,9 @@ end
 Walk `dest` and `srcs` in lockstep, calling `f(dest_leaf, src_leaves...)` for its effect on
 `dest_leaf`, and return `dest`.
 
-As with [`foreachparameters`](@ref), a `nothing` in `srcs` skips that position.
+This is the walk an optimizer runs every iteration, and it allocates nothing at any width or depth. As
+with [`foreachparameters`](@ref), a `nothing` in `srcs` skips that position, and the keys of a keyed
+branch have to agree.
 """
 @inline function mapparameters!(f, dest, srcs::Vararg{Any, N}) where {N}
     foreachparameters(f, dest, srcs...)
@@ -186,7 +202,7 @@ end
 Like [`mapparameters!`](@ref), but `f` is handed the [`freeparameters`](@ref) of each leaf.
 
 No `rebuild` is needed: the storage of a leaf is the leaf's own memory, so writing into it is writing
-into the leaf.
+into the leaf. Allocation-free on the same terms.
 """
 @inline function mapstorage!(f, dest, srcs::Vararg{Any, N}) where {N}
     _foreach_storage(f, dest, srcs...)
@@ -195,13 +211,12 @@ end
 
 @inline function _foreach_storage(f, ps::Union{NetworkParameters, NamedTuple},
         rest::Vararg{Any, N}) where {N}
-    nt = _as_namedtuple(ps)
-    _foreach_zip(f, _storage_recurse, nt, map(r -> _values_for(r, keys(nt)), rest)...)
+    _foreach_zip(f, _storage_recurse, _as_namedtuple(ps), map(_as_namedtuple, rest)...)
     nothing
 end
 
 @inline function _foreach_storage(f, ps::Tuple, rest::Vararg{Any, N}) where {N}
-    _foreach_zip(f, _storage_recurse, ps, map(r -> _tuple_for(r, length(ps)), rest)...)
+    _foreach_zip(f, _storage_recurse, ps, map(_as_tuple, rest)...)
     nothing
 end
 
@@ -273,14 +288,51 @@ end
 # one world age -- so it is only seen when the sources are evaluated, which is what
 # `--compiled-modules=no` does and what `test/world_age_tests.jl` pins. `src/flatten.jl`'s two callers
 # are covered by `walk.jl` being included first.
-function _children_arity(xs, rest...)
+#
+# The same holds for everything else a generator here reaches: `_check_arity`, `_arity_error`,
+# `_branch_keys`, `_child_keys_error` and `_child_expr` below. All of them sit above `_foreach_zip`,
+# which is the only generated body that calls them, and none may be moved past it.
+#
+# `rest` is the *types* of the further sets, as a tuple, and the recursion below is over that tuple —
+# whose length is the arity of the walk, one or two, never the width of a branch. A `Nothing` among them
+# is a set the caller is skipping and has no children to count. Written as a chain and not a loop
+# because `_map_zip` calls this at run time rather than from a generator, and `enumerate` over a
+# heterogeneous tuple of types costs it an allocation there.
+function _children_arity(xs, rest::Tuple)
     n = fieldcount(xs)
-    for (j, r) in enumerate(rest)
-        fieldcount(r) == n || throw(ArgumentError(string(
-            "parameter sets walked together must have the same number of children at every level; ",
-            "got ", n, " and, in argument ", j + 1, ", ", fieldcount(r), ".")))
-    end
+    _check_arity(n, rest, 2)
     n
+end
+
+@inline _check_arity(::Int, ::Tuple{}, ::Int) = nothing
+@inline function _check_arity(n::Int, rest::Tuple, j::Int)
+    r = first(rest)
+    r === Nothing || fieldcount(r) == n || _arity_error(n, j, fieldcount(r))
+    _check_arity(n, Base.tail(rest), j + 1)
+end
+
+@noinline _arity_error(n::Int, j::Int, m::Int) = throw(ArgumentError(string(
+    "parameter sets walked together must have the same number of children at every level; ",
+    "got ", n, " and, in argument ", j, ", ", m, ".")))
+
+# The keys of a branch type, or `nothing` for a branch that has none. A generated body uses it to pair
+# the children of two named branches *by key*, and to say so when they cannot be paired.
+_branch_keys(::Type{<:NamedTuple{Keys}}) where {Keys} = Keys
+_branch_keys(::Type) = nothing
+
+@noinline _child_keys_error(ks, rk, j::Int) = throw(ArgumentError(string(
+    "parameter sets have different keys: ", ks, " and, in argument ", j, ", ", rk)))
+
+# One child of one further set, as an expression: the literal `nothing` for a set being skipped, and
+# `getfield` at a literal index otherwise. Named branches have their keys checked here, in the
+# generator, so the pairing is by key and the check costs nothing at run time — which is the guard
+# `mapparameters` pays `_check_keys` for and the in-place walks used to go without.
+function _child_expr(ks, r::Type, j::Int, i::Int)
+    r === Nothing && return :nothing
+    rk = _branch_keys(r)
+    # `j + 1` and not `j`: the message counts the parameter sets, of which `xs` is the first
+    ks === nothing || rk === nothing || rk === ks || _child_keys_error(ks, rk, j + 1)
+    :(getfield(rest[$j], $i))
 end
 
 @inline _as_namedtuple(x::NetworkParameters) = params(x)
@@ -289,12 +341,6 @@ end
 
 @inline _as_tuple(x::Tuple) = x
 @inline _as_tuple(x::Nothing) = nothing
-
-@inline _values_for(::Nothing, ks::Tuple) = map(_ -> nothing, ks)
-@inline _values_for(x, ::Tuple) = values(_as_namedtuple(x))
-
-@inline _tuple_for(::Nothing, n::Int) = ntuple(_ -> nothing, n)
-@inline _tuple_for(x, ::Int) = x
 
 # `||` and not `any`, so it still short-circuits: the whole point is not to look at the rest once a
 # `nothing` has been found.
@@ -344,13 +390,21 @@ const _WRITE_OUT_MAX_CHILDREN = 32
 # a closure — "The function body AST defined by this @generated function is not pure" — and the `map`
 # arm needs one.
 @inline function _map_zip(recurse, f, xs, rest::Vararg{Any, N}) where {N}
-    _children_arity(typeof(xs), map(typeof, rest)...)
+    # A skipped set is the `foreach` family's affair: there is nothing for an out-of-place walk to put
+    # in the hole, so the answer is an error and not a guess. `_children_arity` lets a `Nothing` past,
+    # because to `_foreach_zip` it means "call nothing here".
+    _anynothing(rest) && _no_skipped_set_error()
+    _children_arity(typeof(xs), map(typeof, rest))
     if fieldcount(typeof(xs)) > _WRITE_OUT_MAX_CHILDREN
         map((cs...) -> recurse(f, cs...), xs, rest...)
     else
         _map_zip_written(recurse, f, xs, rest...)
     end
 end
+
+@noinline _no_skipped_set_error() = throw(ArgumentError(string(
+    "`mapparameters` and `mapstorage` build a new set and so have nothing to put where a `nothing` ",
+    "stands; use `mapparameters!`, `mapstorage!` or `foreachparameters`, which skip that position.")))
 
 @generated function _map_zip_written(recurse, f, xs, rest...)
     n = fieldcount(xs)
@@ -360,9 +414,10 @@ end
 end
 
 @generated function _foreach_zip(f, kind, xs, rest...)
-    n = _children_arity(xs, rest...)
+    n = _children_arity(xs, rest)
+    ks = _branch_keys(xs)
     calls = [Expr(:call, :_foreach_step, :f, :kind, :(getfield(xs, $i)),
-                  (:(getfield(rest[$j], $i)) for j in 1:length(rest))...) for i in 1:n]
+                  (_child_expr(ks, rest[j], j, i) for j in 1:length(rest))...) for i in 1:n]
     quote
         $(calls...)
         nothing
@@ -373,6 +428,13 @@ end
     Any, N}) where {N} = foreachparameters(f, args...)
 @inline _foreach_step(f, ::typeof(_storage_recurse), args::Vararg{
     Any, N}) where {N} = _foreach_storage(f, args...)
+
+# `_map_zip`'s two arms return the children in different shapes: the written-out body a `Tuple`, which
+# has to be keyed, and `Base.map` over a `NamedTuple` a `NamedTuple` that is keyed already. Selecting
+# all `k` fields of the second out of itself is a second `k`-wide generated body and a copy for nothing
+# — 6 272 bytes of the 57 120 a `mapparameters` costs at 369 children.
+@inline _rewrap_children(::NamedTuple{Keys}, children::NamedTuple{Keys}) where {Keys} = children
+@inline _rewrap_children(::NamedTuple{Keys}, children) where {Keys} = NamedTuple{Keys}(children)
 
 @inline _check_keys(::Tuple, ::Tuple{}) = nothing
 @inline function _check_keys(ks::Tuple, nts::Tuple)

--- a/src/walk.jl
+++ b/src/walk.jl
@@ -6,11 +6,27 @@
 # structured types exist — is what keeps `changebackend`, `map_to_cpu`, `_statify`, the elementwise
 # optimizer primitives and the HDF5 traversal from each being their own copy of it.
 #
-# The recursions are written with `Base.tail` rather than with `map` over `keys` so that they stay
-# type stable and allocation free, which `flatten!`/`unflatten!` rely on. The out-of-place `unflatten`
-# and the `unflatten` rrule follow the same rule for the same reason: `map` over a closure cost the
-# first an allocation per leaf on Julia 1.11, and a `for` loop over `keys` cost the second a dynamic
-# dispatch per child on every version. See `_unflatten_children` and `_accumulate_named!`.
+# The walk *down* the tree — `mapparameters` and friends dispatching on `NetworkParameters`,
+# `NamedTuple`, `Tuple` or a leaf — is ordinary multiple dispatch. The walk *across* the children of
+# one branch is not, and it is where the care goes. Neither `map` over `keys` nor a `for` loop will do:
+# `map` over a closure cost the out-of-place `unflatten` an allocation per leaf on Julia 1.11, and a
+# loop over `keys` indexes a heterogeneous tuple at a runtime `i`, which is type-unstable and costs a
+# dynamic dispatch — and a boxed allocation — per child. `flatten!`/`unflatten!` are allocation-free
+# only because neither happens.
+#
+# These across-children walks used to be `@inline`d `Base.tail` chains, which met that bar and
+# introduced a different problem: `Base.tail` produces a *new tuple type at every level*, so a branch
+# with `k` children costs `k` specialisations whose argument types are each `O(k)` long, and inference
+# on that grows as `k³`. Measured, `flatten` on a flat set: 0.17 s at 32 children, 2.2 s at 64, 17.6 s
+# at 128, and past ten minutes at the 369 of the MNIST transformer in GMLDatasets.jl — which is a real
+# parameter set, not a synthetic worst case. Dropping the `@inline` does not help; it makes the same
+# shape slower still (3.2 s at 64) *and* costs 187 808 bytes, because the chain is what kept the
+# per-leaf `copyto!` statically dispatched.
+#
+# So `_children_across` writes the flat body out instead: one `@generated` expansion per branch shape,
+# `k` statements indexing `xs[1] … xs[k]` at *literal* indices. One specialisation instead of `k`, no
+# new tuple types at all, every index inferred at a constant, and the same straight-line code the
+# chain used to inline down to. See open issue D9 in the CHANGELOG for the numbers before and after.
 
 """
     mapparameters(f, ps)
@@ -61,7 +77,7 @@ mapparameters(+, a, c).L1.b
 @inline function mapparameters(f, ps::NamedTuple, rest::Vararg{Any, N}) where {N}
     nts = map(_as_namedtuple, rest)
     _check_keys(keys(ps), nts)
-    NamedTuple{keys(ps)}(_map_zip(mapparameters, f, values(ps), map(values, nts)...))
+    NamedTuple{keys(ps)}(_map_zip(mapparameters, f, ps, nts...))
 end
 
 @inline mapparameters(f, ps::Tuple, rest::Vararg{Any, N}) where {N} = _map_zip(
@@ -101,7 +117,7 @@ mapstorage(x -> x ./ 2, ps).L1.W
 @inline function mapstorage(f, ps::NamedTuple, rest::Vararg{Any, N}) where {N}
     nts = map(_as_namedtuple, rest)
     _check_keys(keys(ps), nts)
-    NamedTuple{keys(ps)}(_map_zip(mapstorage, f, values(ps), map(values, nts)...))
+    NamedTuple{keys(ps)}(_map_zip(mapstorage, f, ps, nts...))
 end
 
 @inline mapstorage(f, ps::Tuple, rest::Vararg{Any, N}) where {N} = _map_zip(
@@ -127,7 +143,7 @@ See [`mapparameters!`](@ref) for the in-place variant that returns its destinati
 @inline function foreachparameters(f, ps::Union{NetworkParameters, NamedTuple},
         rest::Vararg{Any, N}) where {N}
     nt = _as_namedtuple(ps)
-    _foreach_zip(f, freeparameters, values(nt), map(r -> _values_for(r, keys(nt)), rest)...)
+    _foreach_zip(f, freeparameters, nt, map(r -> _values_for(r, keys(nt)), rest)...)
     nothing
 end
 
@@ -171,7 +187,7 @@ end
 @inline function _foreach_storage(f, ps::Union{NetworkParameters, NamedTuple},
         rest::Vararg{Any, N}) where {N}
     nt = _as_namedtuple(ps)
-    _foreach_zip(f, _storage_recurse, values(nt), map(r -> _values_for(r, keys(nt)), rest)...)
+    _foreach_zip(f, _storage_recurse, nt, map(r -> _values_for(r, keys(nt)), rest)...)
     nothing
 end
 
@@ -218,13 +234,19 @@ foldparameters((n, x) -> n + length(x), 0, ps)
 """
 @inline foldparameters(op, init, ps::NetworkParameters) = foldparameters(op, init, params(ps))
 
-@inline foldparameters(op, init, ps::Union{NamedTuple, Tuple}) = _fold_children(op, init, values(ps))
+@inline foldparameters(op, init, ps::Union{NamedTuple, Tuple}) = _fold_children(op, init, ps)
 
 @inline foldparameters(op, init, x) = op(init, x)
 
-@inline _fold_children(op, acc, ::Tuple{}) = acc
-@inline _fold_children(op, acc, xs::Tuple) = _fold_children(
-    op, foldparameters(op, acc, first(xs)), Base.tail(xs))
+# A *left* fold, and the expansion keeps it one: `op` is the caller's and need not be associative,
+# so the nesting below is built inside out rather than halved.
+@generated function _fold_children(op, acc, xs)
+    expr = :acc
+    for i in 1:fieldcount(xs)
+        expr = :(foldparameters(op, $expr, getfield(xs, $i)))
+    end
+    expr
+end
 
 # ---------------------------------------------------------------------------------------------------
 # helpers
@@ -243,26 +265,30 @@ foldparameters((n, x) -> n + length(x), 0, ps)
 @inline _tuple_for(::Nothing, n::Int) = ntuple(_ -> nothing, n)
 @inline _tuple_for(x, ::Int) = x
 
-@inline _anynothing(::Tuple{}) = false
-@inline _anynothing(t::Tuple) = first(t) === nothing || _anynothing(Base.tail(t))
-
-@inline _map_zip(recurse, f, ::Tuple{}) = ()
-@inline _map_zip(recurse, f, xs::Tuple) = (
-    recurse(f, first(xs)), _map_zip(recurse, f, Base.tail(xs))...)
-@inline _map_zip(recurse, f, ::Tuple{}, rest::Tuple{}...) = ()
-@inline _map_zip(recurse, f, xs::Tuple, rest::Tuple...) = (
-    recurse(f, first(xs), map(first, rest)...),
-    _map_zip(recurse, f, Base.tail(xs), map(Base.tail, rest)...)...)
-
-@inline _foreach_zip(f, kind, ::Tuple{}) = nothing
-@inline function _foreach_zip(f, kind, xs::Tuple)
-    _foreach_step(f, kind, first(xs))
-    _foreach_zip(f, kind, Base.tail(xs))
+# `||` and not `any`, so it still short-circuits: the whole point is not to look at the rest once a
+# `nothing` has been found.
+@generated function _anynothing(t::Tuple)
+    fieldcount(t) == 0 && return :(false)
+    tests = [:(getfield(t, $i) === nothing) for i in 1:fieldcount(t)]
+    foldr((a, b) -> :($a || $b), tests)
 end
-@inline _foreach_zip(f, kind, ::Tuple{}, rest::Tuple{}...) = nothing
-@inline function _foreach_zip(f, kind, xs::Tuple, rest::Tuple...)
-    _foreach_step(f, kind, first(xs), map(first, rest)...)
-    _foreach_zip(f, kind, Base.tail(xs), map(Base.tail, rest)...)
+
+# One method for both arities: with no `rest` the inner splat is empty and this is the plain map.
+@generated function _map_zip(recurse, f, xs, rest...)
+    n = _children_arity(xs, rest...)
+    calls = [Expr(:call, :recurse, :f, :(getfield(xs, $i)),
+                  (:(getfield(rest[$j], $i)) for j in 1:length(rest))...) for i in 1:n]
+    :(($(calls...),))
+end
+
+@generated function _foreach_zip(f, kind, xs, rest...)
+    n = _children_arity(xs, rest...)
+    calls = [Expr(:call, :_foreach_step, :f, :kind, :(getfield(xs, $i)),
+                  (:(getfield(rest[$j], $i)) for j in 1:length(rest))...) for i in 1:n]
+    quote
+        $(calls...)
+        nothing
+    end
 end
 
 @inline _foreach_step(f, ::typeof(freeparameters), args::Vararg{
@@ -277,4 +303,17 @@ end
         throw(ArgumentError(string("parameter sets have different keys: ", ks, " and ", keys(other))))
     end
     _check_keys(ks, Base.tail(nts))
+end
+
+# The arity check the `Base.tail` chains used to get for free, by running out of `Tuple{}` methods.
+# Raised from the generated bodies, so it is a clear error at specialisation time rather than a
+# `MethodError` naming a tuple type nobody wrote.
+function _children_arity(xs, rest...)
+    n = fieldcount(xs)
+    for (j, r) in enumerate(rest)
+        fieldcount(r) == n || throw(ArgumentError(string(
+            "parameter sets walked together must have the same number of children at every level; ",
+            "got ", n, " and, in argument ", j + 1, ", ", fieldcount(r), ".")))
+    end
+    n
 end

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -121,10 +121,10 @@ _pullback_allocs(pb, Δ) = @allocated pb(Δ)
 @testset "the pullback does not pay for the depth of the tree" begin
     # the same four leaves, once flat and once one to a layer. The walk is over layouts known at
     # compile time, so the layering cannot show up in the bill. Before it was written this way the two
-    # cost 320 and 1664 bytes on Julia 1.10, and 1088 and 1664 on 1.13, against a 128-byte answer —
-    # the gap is the dynamic dispatch a runtime-`Symbol` lookup into `l.children` forced at every
-    # child. (Both figures now sit at the answer's own cost on 1.10, 1.12 and 1.13; 1.11 adds a fixed
-    # 32 bytes to either, which is why the two are compared with each other and not with `zero`.)
+    # cost 1088 and 1664 bytes on Julia 1.13, against a 128-byte answer — the gap is the dynamic
+    # dispatch a runtime-`Symbol` lookup into `l.children` forced at every child. Both now sit at the
+    # answer's own cost, 128 bytes on 1.11, 1.12 and 1.13; they are still compared with each other
+    # rather than with `zero`, because it is the *depth* that must not show up and not the figure.
     L = [1.0, 2.0]
     function _cost(p)
         w, l = flatten(p)

--- a/test/flatten_tests.jl
+++ b/test/flatten_tests.jl
@@ -83,10 +83,7 @@ end
 end
 
 # Measured from inside a function, which is the claim that matters: `flatten!` allocates nothing when
-# called from compiled code, such as an optimizer inner loop. Measuring at the top level of a testset
-# instead reports a few tens of bytes on Julia 1.10 — the recursion is not specialised in an uninferred
-# top-level context, and the figure tracks the number of leaves rather than anything about the leaves
-# themselves, appearing for plain arrays just as for structured ones.
+# called from compiled code, such as an optimizer inner loop.
 _flatten_allocs(buf, ps, layout) = @allocated flatten!(buf, ps, layout)
 _unflatten_allocs(dest, layout, v) = @allocated unflatten!(dest, layout, v)
 
@@ -101,12 +98,12 @@ _unflatten_allocs(dest, layout, v) = @allocated unflatten!(dest, layout, v)
     @test _unflatten_allocs(dest, layout, v) == 0
 end
 
-# `unflatten` used to be the one walk here written as `map` over a closure rather than as the
-# `Base.tail` recursion the rest of the package uses. Two things came of that, and this pins both.
-# `map` unrolls a tuple only up to 32 elements and drops to `Base`'s `Any32` fallback beyond it, which
+# `unflatten` used to be the one walk here written as `map` over a closure rather than written out the
+# way the rest of the package walks a branch. Two things came of that, and this pins both. `map`
+# unrolls a tuple only up to 32 elements and drops to `Base`'s `Any32` fallback beyond it, which
 # returns a tuple with no concrete type; and the closure over the flat vector is left to be elided,
-# which Julia 1.11 and later do and 1.10 does not — one heap allocation per nesting level per call, on
-# a path `SymbolicNeuralNetworks` runs once per evaluation of a generated function
+# which costs a heap allocation per nesting level per call wherever it is not — on a path
+# `SymbolicNeuralNetworks` runs once per evaluation of a generated function
 # ([SymbolicNeuralNetworks#55](https://github.com/JuliaGNI/SymbolicNeuralNetworks.jl/issues/55)).
 @testset "unflatten stays inferable past 32 children" begin
     keys40 = ntuple(i -> Symbol(:p, i), 40)

--- a/test/parameters_tests.jl
+++ b/test/parameters_tests.jl
@@ -135,3 +135,31 @@ end
 
     @test isconcretetype(only(Base.return_types(NetworkParameters, Tuple{typeof(nt)})))
 end
+
+# `ParameterSet` is the union four packages were spelling out inline. What matters about it is where
+# its edges are, so the tests are the boundary cases rather than the happy path.
+@testset "ParameterSet is either form of a whole parameter set" begin
+    @test ps isa ParameterSet
+    @test nt isa ParameterSet
+    @test nt.L1 isa ParameterSet          # a branch is one too: it is a set of parameters in itself
+    @test NamedTuple() isa ParameterSet
+
+    # a leaf is not, whatever kind of leaf it is
+    @test !([1.0, 2.0] isa ParameterSet)
+    @test !(1.0 isa ParameterSet)
+
+    # and neither is a `Tuple` -- which is where this parts company with `isparametertree`, because a
+    # `Tuple` *is* a branch the walks recurse into (it is what `freeparameters` returns for a
+    # multi-block leaf) but is never a set of parameters handed in whole
+    @test !(([1.0], [2.0]) isa ParameterSet)
+    @test NeuralNetworkParameters.isparametertree(([1.0], [2.0]))
+
+    # the two agree everywhere else, which is the statement that the `Tuple` is the whole difference
+    for x in (ps, nt, nt.L1, NamedTuple(), [1.0, 2.0], 1.0)
+        @test (x isa ParameterSet) == NeuralNetworkParameters.isparametertree(x)
+    end
+
+    # no bound on the element type and none on the depth: a mixed-precision, unevenly nested set is
+    # still one. This is the difference from `GeometricOptimizers.ParameterContainer{T}`.
+    @test (a = Float32[1.0], b = (c = Float64[2.0], d = (e = [3],))) isa ParameterSet
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,9 @@ end
 @safetestset "Flat parameters           " begin
     include("flat_parameters_tests.jl")
 end
+@safetestset "Wide branches             " begin
+    include("wide_branch_tests.jl")
+end
 @safetestset "Derivatives               " begin
     include("derivative_tests.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,9 @@ end
 @safetestset "Wide branches             " begin
     include("wide_branch_tests.jl")
 end
+@safetestset "World age                 " begin
+    include("world_age_tests.jl")
+end
 @safetestset "Derivatives               " begin
     include("derivative_tests.jl")
 end

--- a/test/walk_tests.jl
+++ b/test/walk_tests.jl
@@ -75,6 +75,50 @@ end
     @test length(visited) == 1
 end
 
+# `mapparameters` has always raised when two sets disagree on their keys; the in-place walks used to zip
+# them *by position* instead, so a gradient tree whose keys were ordered differently wrote every leaf
+# into the wrong parameter and said nothing. The check is in the generator now, which is why these are
+# `ArgumentError`s at specialisation time and cost the walk nothing.
+@testset "the in-place walks pair children by key, not by position" begin
+    dest = NetworkParameters((a = [0.0], b = [0.0]))
+
+    @test_throws "different keys" foreachparameters(
+        copyto!, dest, NetworkParameters((b = [10.0], a = [99.0])))
+    @test_throws "different keys" mapparameters!(
+        copyto!, dest, NetworkParameters((x = [1.0], y = [2.0])))
+    @test_throws "different keys" mapstorage!(
+        copyto!, dest, NetworkParameters((b = [1.0], a = [2.0])))
+    @test dest.a == [0.0] && dest.b == [0.0]
+
+    # a nested set is checked at the level the keys disagree on and not only at the top
+    @test_throws "different keys" mapparameters!(copyto!,
+        NetworkParameters((L = (W = [0.0], b = [0.0]),)),
+        NetworkParameters((L = (b = [1.0], W = [2.0]),)))
+
+    # the same keys in the same order still walk, whichever form each side arrives in
+    d = (a = [0.0], b = [0.0])
+    foreachparameters(copyto!, d, NetworkParameters((a = [1.0], b = [2.0])))
+    @test d == (a = [1.0], b = [2.0])
+end
+
+# A positional branch is the blocks of one multi-block leaf, so it is short — but `_tuple_for` used to
+# fill it against a `nothing` with an `ntuple` over a *runtime* length, which stops being inferable past
+# ten. The generated body splices the `nothing`s in as literals now, so there is no length to be runtime
+# about.
+@testset "a positional branch of more than ten blocks stays inferable" begin
+    blocks = ntuple(i -> [Float64(i)], 12)
+    @test only(Base.return_types(foreachparameters,
+        Tuple{typeof(sum), typeof(blocks), Nothing})) === Nothing
+
+    dest = ntuple(_ -> [0.0], 12)
+    foreachparameters(copyto!, dest, blocks)
+    @test dest == blocks
+
+    touched = Ref(0)
+    foreachparameters((_, _) -> (touched[] += 1), dest, nothing)
+    @test touched[] == 0
+end
+
 @testset "foldparameters" begin
     # whole leaves, so the structured leaves count their dense length
     @test foldparameters((n, x) -> n + length(x), 0, ps) == 2 + 1 + 4 + 9

--- a/test/wide_branch_tests.jl
+++ b/test/wide_branch_tests.jl
@@ -85,9 +85,11 @@ end
     @test touched[] == 0
 end
 
-@testset "a wide branch is a parameter tree" begin
+@testset "a wide branch is a ParameterSet and a parameter tree" begin
     ps = wide_set(369)
+    @test ps isa ParameterSet
     @test isparametertree(ps)
+    @test NetworkParameters(ps) isa ParameterSet
     @test parameter_eltype(ps) == Float32
 end
 

--- a/test/wide_branch_tests.jl
+++ b/test/wide_branch_tests.jl
@@ -40,6 +40,14 @@ nested_set(k) = NamedTuple{Tuple(Symbol("L", i) for i in 1:k)}(
 _flatten_allocs(buf, ps, layout) = @allocated flatten!(buf, ps, layout)
 _unflatten_allocs(dest, layout, v) = @allocated unflatten!(dest, layout, v)
 
+# The `foreach` family has to be measured through a **zero-argument** closure, and that is not a
+# stylistic choice. `@allocated f(a, b)` lowers to `Base.allocated(f, a, b)`, and `foreachparameters`,
+# `mapparameters!` and `mapstorage!` are `Vararg` methods — so the splat inside `Base.allocated`
+# allocates on its own account, which both invents bytes these walks do not spend and hides the ones
+# they do. `flatten!` is not a `Vararg` method, which is why the two helpers above can be written the
+# obvious way. `@allocated thunk()` takes no arguments to splat.
+_thunk_allocs(thunk) = (thunk(); thunk(); @allocated thunk())
+
 @testset "flatten and unflatten reach a branch of $k children" for k in WIDTHS
     ps = wide_set(k)
     v, layout = flatten(ps)
@@ -92,6 +100,34 @@ end
     @test touched[] == 0
 end
 
+# The in-place walks at every arity, which is the half of D13 that `flatten!` and `unflatten!` do not
+# cover. Zipping two sets used to take `values` of each branch of *each* argument, which is the same
+# temporary per branch the forward walks stopped taking: `mapparameters!` cost 800 bytes a call on a
+# flat 48-child set and 6 144 at 369, and three to four times that on a branch of branches. These are
+# the walks an optimizer runs every iteration, where `flatten!` runs once or twice, so they are the
+# ones the guarantee is worth most on.
+@testset "the walks that take two sets do not allocate at $k children" for k in WIDTHS
+    ps = wide_set(k)
+    dest = mapparameters(zero, ps)
+    counted = Ref(0)
+    bump1(_) = (counted[] += 1; nothing)
+    bump2(_, _) = (counted[] += 1; nothing)
+    bump3(_, _, _) = (counted[] += 1; nothing)
+
+    @test _thunk_allocs(() -> foreachparameters(bump1, dest)) == 0
+    @test _thunk_allocs(() -> foreachparameters(bump2, dest, ps)) == 0
+    @test _thunk_allocs(() -> mapparameters!(bump2, dest, ps)) == 0
+    @test _thunk_allocs(() -> mapparameters!(bump3, dest, ps, ps)) == 0
+    @test _thunk_allocs(() -> mapstorage!(bump2, dest, ps)) == 0
+    # the `nothing` skip too: it used to fill the branch with a fresh tuple of `nothing`s per call
+    @test _thunk_allocs(() -> foreachparameters(bump2, dest, nothing)) == 0
+
+    # and the walk really ran, rather than being elided as the dead code a side-effect-free `f` is
+    @test counted[] > 0
+    mapparameters!(copyto!, dest, ps)
+    @test dest == ps
+end
+
 # 48 and not 369: the width is covered above, and what nesting adds is a branch whose children are
 # branches, which 48 is already well past the unrolling boundary for. A real consumer has one shape or
 # the other — the 369-child set is flat, and a network with a child per layer is dozens deep, not
@@ -110,6 +146,15 @@ end
     _unflatten_allocs(dest, layout, v)
     @test _flatten_allocs(buf, ps, layout) == 0
     @test _unflatten_allocs(dest, layout, v) == 0
+
+    # the two-set walks on the shape that has a branch to take apart at every child, which is where a
+    # temporary per branch per argument costs the most
+    counted = Ref(0)
+    bump2(_, _) = (counted[] += 1; nothing)
+    @test _thunk_allocs(() -> mapparameters!(bump2, dest, ps)) == 0
+    @test _thunk_allocs(() -> mapstorage!(bump2, dest, ps)) == 0
+    @test _thunk_allocs(() -> foreachparameters(bump2, dest, nothing)) == 0
+    @test counted[] > 0
 end
 
 @testset "a wide branch is a ParameterSet and a parameter tree" begin

--- a/test/wide_branch_tests.jl
+++ b/test/wide_branch_tests.jl
@@ -27,9 +27,16 @@ const WIDTHS = (48, 369)
 wide_set(k) = NamedTuple{Tuple(Symbol("p", i) for i in 1:k)}(
     Tuple(fill(Float32(i), 2, 2) for i in 1:k))
 
-# Allocations are measured from inside a function throughout, for the reason
-# `flatten_tests.jl` gives: at the top level the walk is not specialised and the figure is the
-# harness's, not the code's.
+# The same width with a layer's worth of nesting under each child, which is the shape a network of
+# many layers actually has. `wide_set` exercises the width alone: its children are arrays, and an
+# array is already a heap object, so a walk that reaches one has nothing to keep off the heap. Under
+# `nested_set` every child is a branch that a walk has to take apart in place, and that is where a
+# walk which is written correctly for the width but not inlined shows up.
+nested_set(k) = NamedTuple{Tuple(Symbol("L", i) for i in 1:k)}(
+    Tuple((W = fill(Float32(i), 2, 2), b = fill(Float32(i), 2)) for i in 1:k))
+
+# Allocations are measured from inside a function throughout, for the reason `flatten_tests.jl` gives:
+# that is the claim that matters, an optimizer's inner loop rather than the top level of a testset.
 _flatten_allocs(buf, ps, layout) = @allocated flatten!(buf, ps, layout)
 _unflatten_allocs(dest, layout, v) = @allocated unflatten!(dest, layout, v)
 
@@ -85,6 +92,26 @@ end
     @test touched[] == 0
 end
 
+# 48 and not 369: the width is covered above, and what nesting adds is a branch whose children are
+# branches, which 48 is already well past the unrolling boundary for. A real consumer has one shape or
+# the other — the 369-child set is flat, and a network with a child per layer is dozens deep, not
+# hundreds — and the nested 369 would cost the suite another minute to say nothing the 48 does not.
+@testset "a wide branch of branches round-trips and does not allocate at $k children" for k in (48,)
+    ps = nested_set(k)
+    v, layout = flatten(ps)
+
+    @test length(v) == 6k
+    @test unflatten(layout, v) == ps
+    @test mapparameters(x -> 2x, ps).L1.W == 2 * ps.L1.W
+
+    buf = similar(v)
+    dest = unflatten(layout, zero(v))
+    _flatten_allocs(buf, ps, layout)          # warm up the call and the measurement
+    _unflatten_allocs(dest, layout, v)
+    @test _flatten_allocs(buf, ps, layout) == 0
+    @test _unflatten_allocs(dest, layout, v) == 0
+end
+
 @testset "a wide branch is a ParameterSet and a parameter tree" begin
     ps = wide_set(369)
     @test ps isa ParameterSet
@@ -93,10 +120,14 @@ end
     @test parameter_eltype(ps) == Float32
 end
 
-# The arity check the `Base.tail` chains used to get by running out of `Tuple{}` methods, and which the
-# written-out bodies have to raise for themselves.
-@testset "walking branches of different widths is an error" begin
-    @test_throws ArgumentError mapparameters(+, wide_set(48), wide_set(47))
+# Two checks, and a pair of wide `NamedTuple`s only ever reaches the first of them: branches of
+# different widths are keyed differently, so `_check_keys` rejects them before any walk starts. The
+# arity check the `Base.tail` chains used to get by running out of `Tuple{}` methods, and which the
+# written-out bodies raise for themselves, is reachable only through a *positional* branch — a
+# multi-block leaf whose blocks do not line up.
+@testset "walking mismatched branches is an error" begin
+    @test_throws "different keys" mapparameters(+, wide_set(48), wide_set(47))
+    @test_throws "same number of children" mapparameters(+, ([1.0], [2.0]), ([1.0],))
 end
 
 # The reverse pass over a wide branch. `_accumulate_named!` was the one walk in `src/derivatives.jl`

--- a/test/wide_branch_tests.jl
+++ b/test/wide_branch_tests.jl
@@ -1,0 +1,119 @@
+# A branch with many children.
+#
+# Every walk across the children of one branch used to be an `@inline`d `Base.tail` chain, which cost
+# one specialisation per child over argument types each as long as the branch — so inference on it grew
+# as the cube of the width. `flatten` on a flat set took 0.17 s at 32 children, 2.2 s at 64, 17.6 s at
+# 128 and was not usable at all at 369.
+#
+# 369 is not a synthetic number. It is the parameter set of the MNIST transformer in
+# `scripts/geometric_optimizers/mnist.jl` of GMLDatasets.jl — 3·7·16 attention projections, 2·16 ResNet
+# parameters and one classification weight, in one flat `NamedTuple` — which is written against this
+# package alone. So this file is the width a real consumer has, not a limit chosen to be safe.
+#
+# What it pins is the property, not the timing: that the walks reach a wide branch at all, keep the
+# shape, and stay allocation-free there. A wall-clock assertion would be a flake on a loaded CI
+# machine; the timings live in the CHANGELOG beside the harness that produced them. The `@test` that
+# this file *completes* is the regression test — the version before the fix does not.
+
+using NeuralNetworkParameters
+using NeuralNetworkParameters: isparametertree
+using ChainRulesCore
+using Test
+
+# 369 for the reason above, and 48 as well: `Base` unrolls a tuple up to 32 fields and drops to a loop
+# past it, so a case either side of that edge is worth having when a walk is rewritten.
+const WIDTHS = (48, 369)
+
+wide_set(k) = NamedTuple{Tuple(Symbol("p", i) for i in 1:k)}(
+    Tuple(fill(Float32(i), 2, 2) for i in 1:k))
+
+# Allocations are measured from inside a function throughout, for the reason
+# `flatten_tests.jl` gives: at the top level the walk is not specialised and the figure is the
+# harness's, not the code's.
+_flatten_allocs(buf, ps, layout) = @allocated flatten!(buf, ps, layout)
+_unflatten_allocs(dest, layout, v) = @allocated unflatten!(dest, layout, v)
+
+@testset "flatten and unflatten reach a branch of $k children" for k in WIDTHS
+    ps = wide_set(k)
+    v, layout = flatten(ps)
+
+    @test length(v) == 4k
+    @test flatlength(ps) == 4k
+    @test unflatten(layout, v) == ps
+    # the order is the order of the keys, so the last leaf is the last four entries
+    @test v[end-3:end] == fill(Float32(k), 4)
+end
+
+@testset "the in-place forms do not allocate at $k children" for k in WIDTHS
+    ps = wide_set(k)
+    v, layout = flatten(ps)
+    buf = similar(v)
+    dest = unflatten(layout, zero(v))
+
+    _flatten_allocs(buf, ps, layout)          # warm up the call and the measurement
+    _unflatten_allocs(dest, layout, v)
+    @test _flatten_allocs(buf, ps, layout) == 0
+    @test _unflatten_allocs(dest, layout, v) == 0
+end
+
+@testset "the walks reach a branch of $k children" for k in WIDTHS
+    ps = wide_set(k)
+
+    doubled = mapparameters(x -> 2x, ps)
+    @test keys(doubled) == keys(ps)
+    @test doubled.p1 == 2 * ps.p1
+    @test doubled[Symbol("p", k)] == 2 * ps[Symbol("p", k)]
+
+    # two sets in lockstep, which is the arity that used to `Base.tail` both tuples at once
+    summed = mapparameters(+, ps, ps)
+    @test summed.p1 == 2 * ps.p1
+
+    @test foldparameters((acc, x) -> acc + sum(x), 0.0f0, ps) ==
+          sum(sum, values(ps))
+
+    dest = mapparameters(zero, ps)
+    mapparameters!(copyto!, dest, ps)
+    @test dest == ps
+
+    visited = Ref(0)
+    foreachparameters(_ -> (visited[] += 1), ps)
+    @test visited[] == k
+
+    # the `nothing` skip, which short-circuits over a wide branch
+    touched = Ref(0)
+    foreachparameters((_, _) -> (touched[] += 1), ps, nothing)
+    @test touched[] == 0
+end
+
+@testset "a wide branch is a parameter tree" begin
+    ps = wide_set(369)
+    @test isparametertree(ps)
+    @test parameter_eltype(ps) == Float32
+end
+
+# The arity check the `Base.tail` chains used to get by running out of `Tuple{}` methods, and which the
+# written-out bodies have to raise for themselves.
+@testset "walking branches of different widths is an error" begin
+    @test_throws ArgumentError mapparameters(+, wide_set(48), wide_set(47))
+end
+
+# The reverse pass over a wide branch. `_accumulate_named!` was the one walk in `src/derivatives.jl`
+# that a branch of layers makes wide, and a gradient step runs it on every call — so it is worth an
+# assertion of its own rather than being taken on trust from the forward direction.
+@testset "the pullback of unflatten reaches a branch of $k children" for k in WIDTHS
+    ps = wide_set(k)
+    v, layout = flatten(ps)
+    _, pullback = ChainRulesCore.rrule(unflatten, layout, v)
+
+    # a cotangent of ones in the shape of the parameters comes back as a flat vector of ones: every
+    # leaf has to be found, and found at the right range. `one.(x)` and not `one(x)`: `one` of a matrix
+    # is the identity, so the latter asks for the diagonal and gets it.
+    Δ = pullback(mapparameters(x -> one.(x), ps))[3]
+    @test Δ == ones(Float32, 4k)
+
+    # a branch the cotangent is silent about is a structural zero rather than an error
+    partial = NamedTuple{(:p1,)}((one.(ps.p1),))
+    Δp = pullback(partial)[3]
+    @test Δp[1:4] == ones(Float32, 4)
+    @test all(iszero, Δp[5:end])
+end

--- a/test/world_age_tests.jl
+++ b/test/world_age_tests.jl
@@ -1,0 +1,58 @@
+# The generated walks still work when the sources are evaluated rather than loaded from a cache.
+#
+# Every across-children walk is a `@generated` function, and four of them call `_children_arity` from
+# the *generator* body. A generator runs in the world age of its own method definition, so a helper
+# defined further down the file is invisible to it and the generator raises
+# `MethodError: no method matching _children_arity(…)  The applicable method may be too new`. That is
+# a real defect and it was one: `_children_arity` used to sit at the foot of `src/walk.jl`, below
+# `_map_zip` and `_foreach_zip`.
+#
+# It cannot be caught in-process. Loading a precompiled package deserialises every method in the
+# module into one world age, which is exactly the condition that hides it — so the whole of the rest
+# of this suite passes with the bug present. `--compiled-modules=no` is what evaluates the sources,
+# and a subprocess is the only way to ask for it.
+#
+# Cheap enough to keep: the package's dependency is `ChainRulesCore`, so a from-source load is about a
+# second. The walks exercised below are the four whose generators call `_children_arity`
+# (`_map_zip`, `_foreach_zip` and, through `flatten`, `_flatten_children!` and `_unflatten_children!`)
+# plus `_fold_children`, whose generator calls only `Base`.
+
+using Test
+
+const _WORLD_AGE_PROGRAM = """
+using NeuralNetworkParameters
+
+ps = (L1 = (W = [1.0 2.0], b = [3.0]), L2 = (W = [4.0;;],))
+
+# `_map_zip`
+mapparameters(zero, ps) == (L1 = (W = [0.0 0.0], b = [0.0]), L2 = (W = [0.0;;],)) || exit(1)
+mapparameters(+, ps, ps).L1.b == [6.0] || exit(2)
+
+# `_foreach_zip`
+let n = Ref(0)
+    foreachparameters(_ -> n[] += 1, ps)
+    n[] == 3 || exit(3)
+end
+
+# `_flatten_children!`, `_unflatten_children`, `_unflatten_children!`, `_layout`,
+# `_promote_eltypes`
+v, layout = flatten(ps)
+v == [1.0, 2.0, 3.0, 4.0] || exit(4)
+unflatten(layout, v) == ps || exit(5)
+let qs = mapparameters(zero, ps)
+    unflatten!(qs, layout, v)
+    qs == ps || exit(6)
+end
+
+# `_fold_children`
+foldparameters((a, x) -> a + length(x), 0, ps) == 4 || exit(7)
+
+exit(0)
+"""
+
+@testset "the generated walks survive a from-source load" begin
+    project = dirname(@__DIR__)
+    cmd = `$(Base.julia_cmd()) --startup-file=no --compiled-modules=no --project=$project
+           -e $_WORLD_AGE_PROGRAM`
+    @test success(pipeline(cmd; stdout = devnull, stderr = devnull))
+end

--- a/test/world_age_tests.jl
+++ b/test/world_age_tests.jl
@@ -1,8 +1,9 @@
 # The generated walks still work when the sources are evaluated rather than loaded from a cache.
 #
 # Every across-children walk is a `@generated` function, and four of them call `_children_arity` from
-# the *generator* body. A generator runs in the world age of its own method definition, so a helper
-# defined further down the file is invisible to it and the generator raises
+# the *generator* body — as does, for a walk over more than one set, the chain of `_branch_keys`,
+# `_child_expr` and their two error helpers. A generator runs in the world age of its own method
+# definition, so a helper defined further down the file is invisible to it and the generator raises
 # `MethodError: no method matching _children_arity(…)  The applicable method may be too new`. That is
 # a real defect and it was one: `_children_arity` used to sit at the foot of `src/walk.jl`, below
 # `_map_zip` and `_foreach_zip`.
@@ -15,7 +16,9 @@
 # Cheap enough to keep: the package's dependency is `ChainRulesCore`, so a from-source load is about a
 # second. The walks exercised below are the four whose generators call `_children_arity`
 # (`_map_zip`, `_foreach_zip` and, through `flatten`, `_flatten_children!` and `_unflatten_children!`)
-# plus `_fold_children`, whose generator calls only `Base`.
+# plus `_fold_children`, whose generator calls only `Base`. `_foreach_zip` is run at **two** arities,
+# because the key and index helpers a further set needs are only reached at the second — one set has no
+# second set to pair against, so an arity-one walk would leave exactly that chain of helpers untried.
 
 using Test
 
@@ -28,10 +31,22 @@ ps = (L1 = (W = [1.0 2.0], b = [3.0]), L2 = (W = [4.0;;],))
 mapparameters(zero, ps) == (L1 = (W = [0.0 0.0], b = [0.0]), L2 = (W = [0.0;;],)) || exit(1)
 mapparameters(+, ps, ps).L1.b == [6.0] || exit(2)
 
-# `_foreach_zip`
+# `_foreach_zip` at arity one
 let n = Ref(0)
     foreachparameters(_ -> n[] += 1, ps)
     n[] == 3 || exit(3)
+end
+
+# `_foreach_zip` at arity two, which is what reaches `_branch_keys` and `_child_expr` from a generator
+let dest = mapparameters(zero, ps)
+    mapparameters!(copyto!, dest, ps)
+    dest == ps || exit(8)
+end
+
+# and the `nothing` skip, which is the other branch of `_child_expr`
+let n = Ref(0)
+    foreachparameters((_, _) -> n[] += 1, ps, nothing)
+    n[] == 0 || exit(9)
 end
 
 # `_flatten_children!`, `_unflatten_children`, `_unflatten_children!`, `_layout`,


### PR DESCRIPTION
A branch with many children is usable. 0.2.1 finished making the walks type stable and allocation free; this makes them *compilable* on a branch wider than a couple of dozen children, which they were not.

Found from the review of [GeometricOptimizers #68](https://github.com/JuliaGNI/GeometricOptimizers.jl/pull/68), which needed `mapparameters` on the one parameter shape it has a named consumer for, could not compile it, and wrote its own `map`-based walk instead. **Everything in that stack now depends on this**, so it wants to land first.

## The defect

The walk *down* the tree is ordinary dispatch and was never the problem. The walk *across* the children of one branch was an `@inline`d `Base.tail` chain — and `Base.tail` yields a **new tuple type at every level**, so a branch of `k` children costs `k` specialisations whose argument types are each `O(k)` long, and inference on that grows as `k³`.

Ten walks were written that way: `_flatten_children!`, `_unflatten_children`, `_unflatten_children!`, `_map_zip`, `_foreach_zip`, `_fold_children`, `_anynothing`, `_promote_eltypes`, `_layout_children`, and `_accumulate_named!` on the reverse pass.

`369` is the number that makes this a defect rather than a curiosity: it is the parameter set of the MNIST transformer in `scripts/geometric_optimizers/mnist.jl` of [GMLDatasets.jl](https://github.com/JuliaGNI/GMLDatasets.jl) — 3·7·16 attention projections, 2·16 ResNet parameters and one classification weight, in one flat `NamedTuple` — written against this package alone. `flatten` is on the path of every `GeometricOptimizers.GradientAutodiff`, so that network could not be optimized through this package at all.

## The fix, and two answers that look obvious and are wrong

The walks are written out as `@generated` flat bodies of `k` statements reading `getfield(xs, 1) … getfield(xs, k)` at **literal** indices: one specialisation per branch shape instead of `k`, no new tuple types at all, every index inferred at a constant, and the same straight-line code the chain used to inline down to.

`scripts/wide_branch_cost.jl` is committed as the harness. Total compile cost of the whole path — `parameterlayout`, `mapparameters`, `flatten`, `unflatten` — on a flat `NamedTuple` of `k` leaves, one process per width, Julia 1.13.0-rc2:

| children | 0.2.1 | 0.2.2 |
|---|---|---|
| 32 | 0.87 s | **0.80 s** |
| 48 | 4.24 s | **0.99 s** |
| 64 | 10.05 s | **1.36 s** |
| 128 | 85.90 s | **3.34 s** |
| 369 | still compiling `parameterlayout` after 20 min | **24.65 s** |

`map(zero, ·)` is 0.01–0.02 s throughout on both and is in the harness as the floor — it is what `Base` costs on the same branch, and what a consumer that wrote its own walk over `map` to get around this was paying instead.

> **This table has been re-measured twice since the branch was opened**, and the figures it first quoted were wrong both times — 17.57 s for `flatten` at 128 children and "not run to completion" at 369, then 0.00 s for everything. Neither was a matter of magnitude. The harness swept its widths in one process, so every row after the first measured what its predecessors had compiled; and `first_call` timed a direct `f(args...)`, so compiling `first_call` itself inferred through the call before its own clock started. Both are fixed, both are recorded in `CHANGELOG.md` as D16 and D19, and the corrected margin is wider than either wrong version claimed. The lesson is one line: **arrange the harness so the cost cannot have been paid somewhere the clock is not looking.**

Both of the obvious cheaper fixes are wrong, and the harness is what says so:

- **Dropping the `@inline`** leaves the `k` specialisations exactly where they are. The same 64-child set goes from 2.16 s to **3.22 s** *and* starts allocating 187 808 bytes, because the inlining was what kept the per-leaf `copyto!` statically dispatched.
- **A loop over the children**, which is what `Base.map` falls back to past 32 fields, indexes a heterogeneous tuple at a runtime `i`. That is type-unstable, so a dynamic dispatch and a boxed allocation per child — the end of the property 0.2.1 exists to provide.

## Further defects fell out, and all of them were live

Same cliff, seen from other sides. Neither was hypothetical; this package's own docstrings promised otherwise and the suite was affirming them, because every set it tested was narrow enough to stay below the cliff.

**`flatten!` and `unflatten!` allocated past about forty children.** Two temporary tuples were materialised per branch — `values(ps)` and `values(l.children)` — which is free while a branch stays in registers and is not beyond that. The walks index the branch in place with `getfield` now and take no `values` at all.

| children | 32 | 48 | 64 | 128 | 369 |
|---|---|---|---|---|---|
| 0.2.1 | 0 | 70 288 | 160 928 | 770 624 | 6 608 576 |
| 0.2.2 | 0 | **0** | **0** | **0** | **0** |

**The reverse pass had it too.** `_accumulate_named!` is written out with the branch's keys spliced in as *literal* `Symbol`s — which is also what keeps `_cotangent_get`'s `haskey` a compile-time question, the property the chain had been leaving to constant propagation. Bytes per pullback call:

| children | 16 | 32 | 48 | 64 | 128 | 369 |
|---|---|---|---|---|---|---|
| 0.2.1 | 320 | 576 | 70 592 | 161 504 | not reached | not reached |
| 0.2.2 | 320 | 576 | **848** | **1 120** | **2 112** | **6 208** |

**And the in-place walks that take a *second* set had it, and needed a second pass to find.** Removing the temporary from the branch being walked took `mapparameters!` from 23 488 bytes a call at 48 children to 800 — which looks like the defect closing and is the cliff moved, because each *further* argument was still turned into a `values(...)` tuple per branch. These are the walks an optimizer runs every iteration, where `flatten!` runs once or twice.

| children | 16 | 32 | 48 | 64 | 128 | 369 |
|---|---|---|---|---|---|---|
| 0.2.1 | 0 | 0 | 23 488 | 54 848 | 265 408 | — |
| this branch, first pass | 0 | 0 | 800 | 1 088 | 2 176 | 6 144 |
| **now** | 0 | 0 | **0** | **0** | **0** | **0** |

Not caught by the wide-branch tests as first written, which *did* call `mapparameters!` at 369 children and asserted only its result. Measuring it needs a zero-argument closure: `@allocated f(a, b)` lowers to `Base.allocated(f, a, b)`, and for a `Vararg` method — which all three of these are — the splat inside `Base.allocated` allocates on its own account, inventing bytes the walk does not spend and hiding the ones it does.

Two more came out with it. **The in-place walks paired the children of two keyed branches by *position*** — `_values_for(x, ks)` ignored its `ks`, so two same-shaped sets whose keys were ordered differently wrote every leaf into the wrong parameter without a word, where `mapparameters` has always raised. The keys are checked in the generator now, so the guard is free at run time and stricter than `_check_keys`; **this is a behaviour change.** And `_tuple_for` filled a positional branch with an `ntuple` over a *runtime* length, which infers as `Tuple{Vararg{Nothing}}` past ten blocks — the very instability `src/derivatives.jl` records removing from `_matching_positional`.

Identical up to 32 children and 144× better at 64, which is the signature of the same cliff. The two *positional* walks — `_accumulate_positional!` and `_matching_positional` — are deliberately left as chains, and the comment beside them now says why: their length is the block count of a *single leaf*, two for a `StiefelLieAlgHorMatrix` and one for a Grassmann lift, so they are never wide the way a branch of layers is.

## `ParameterSet`

Exported: `Union{NetworkParameters, NamedTuple}`, the type to dispatch on when a method takes *the parameters* and does not care which of the two forms it was handed.

Every package in this ecosystem was answering that question for itself — `AbstractNeuralNetworks` spelled the union out at eight sites, `GeometricMachineLearning` at fifteen, `GeometricOptimizers` at sixteen, and `SymbolicNeuralNetworks` had named it `EquationSet`. `GeometricOptimizers` additionally has a *narrower* alias, `ParameterContainer{T}`, and those sixteen inline sites are the measurement of where it does not fit: `T` is a per-leaf guarantee *plus flatness* on one arm and a promotion over any depth on the other.

The docstring states the two things it is not:

- **Not `isparametertree`**, which is also true of a `Tuple` — because a `Tuple` *is* a branch the walks recurse into (it is what `freeparameters` returns for a multi-block leaf, and why `TupleLayout` exists) but never a set of parameters handed in whole, which is always keyed. `test/parameters_tests.jl` asserts that the two agree on everything *except* the `Tuple`s, rather than asserting the happy path.
- **Not `ParameterContainer{T}`**: no bound on the element type and none on the depth.

## Tests

`test/wide_branch_tests.jl` walks a **369-child** branch through `flatten`/`unflatten`, `mapparameters` at both arities, `mapparameters!`, `foreachparameters` with and without the `nothing` skip, `foldparameters`, `parameter_eltype`, the `unflatten` pullback with a full and a partial cotangent, and pins **every** in-place form at zero allocations there — `flatten!` and `unflatten!`, and `mapparameters!`, `mapstorage!` and `foreachparameters` at arity one, two and three and on the `nothing`-skip path, in both the flat and the branch-of-branches shape. It also covers 48, either side of the 32 fields `Base` unrolls a tuple up to, and asserts that walking branches of different widths raises — the arity check the `Tuple{}` base cases used to give for free.

It asserts *properties* and not timings: a wall-clock bound would be a flake on a loaded machine, so the regression test is that the file **completes**, which before this it did not. It costs the suite about 40 s, all of it compilation at the wide width, and that is the honest price of covering the width a consumer actually has rather than the width that is convenient.

424 tests green; doctests green.

## Downstream

Four PRs are queued behind this one and are green against it locally: `GeometricOptimizers` [#68](https://github.com/JuliaGNI/GeometricOptimizers.jl/pull/68) and [#69](https://github.com/JuliaGNI/GeometricOptimizers.jl/pull/69) both bump to `NeuralNetworkParameters = "0.2.2"`, and `AbstractNeuralNetworks`, `SymbolicNeuralNetworks` and `GeometricMachineLearning` adopt `ParameterSet`. `GeometricOptimizers` also retires one of the five type-piracy sites of its issue #16 as a consequence.

`PLAN.md` is revised with what this changed: §4 gains D12, D13 and D14, §6 gains `ParameterSet`, and §8's `GeometricOptimizers` entry is rewritten, since all three of its steps have now shipped and none of them in the order it predicted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

