### PR TITLE
Sweep the shape a consumer holds, not only the one that is cheap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,15 @@ they were not.
   what `Base` costs on the same branch, and what a consumer that wrote its own walk over `map` to get
   around this was paying instead.
 
+  **Every set above is a bare `NamedTuple`, and the `parameterlayout` column reads low because of it.**
+  A consumer holds a `NetworkParameters`, which reaches the walk through one more method, and on
+  Julia 1.11 that method is what the column costs: 13.44 s at 369 children against the 1.35 s above,
+  and 88.69 s at 768 against 2.73 s. It is the *entry point* and not the total — the whole path,
+  `parameterlayout` then `flatten` then `unflatten`, is 21.66 s bare and 22.41 s wrapped at 369 — and
+  Julia 1.12 and 1.13 do not distinguish the two shapes at all (1.78 s and 1.67 s wrapped at 369). The
+  sweep runs both shapes now; see D20 in `PLAN.md` and the note above
+  `_layout(::NetworkParameters, ::Int)` in `src/layout.jl`.
+
   The `flatten` column is the one that goes the wrong way at the two largest widths, and it is a
   re-attribution rather than a loss: `parameterlayout` no longer absorbs the shared compilation, so
   `flatten` pays for it instead. Measured alone in its own process at 369 children, `flatten` is

--- a/PLAN.md
+++ b/PLAN.md
@@ -151,14 +151,22 @@ checkouts, so §8 is now written as *where each package stands* rather than as a
 ## 4. Defects on record
 
 D1, D2, D3, D4, D7, D8, D9, D10, D11, D12, D13 and D14 are fixed — which is all of them but D5 and
-D6, and those two are open *in `GeometricOptimizers`* rather than here. D15 through D19 are new in this
-revision and are all five defects of this package's own 0.2.2 work, found by running it rather than by
+D6, and those two are open *in `GeometricOptimizers`* rather than here. D15 through D20 are new in this
+revision and are all six defects of this package's own 0.2.2 work, found by running it rather than by
 reading it.
 
 **D17 and D18 came from reviewing 0.2.2 itself**, and the lesson is narrower than D16's and worth as
 much: D13 was fixed on the two walks the tests measured, and the three that take a second set were
 neither fixed nor measured — while being the walks that run every iteration rather than once. A
 guarantee holds where it is asserted and nowhere else.
+
+**D16, D19 and D20 are one lesson from three sides: a harness reports what it is pointed at.** D16
+swept its widths in one process, so every row but the first measured what its predecessors had
+compiled. D19 timed a direct call, so the inference being timed was spent before the clock started.
+D20 is the argument rather than the clock — every set the sweep and the wide-branch tests build is a
+bare `NamedTuple`, and a consumer holds a `NetworkParameters`. On Julia 1.11 that is 1.37 s against
+13.44 s for `parameterlayout` on the same 369 leaves, so the committed table reports the cheap column
+and calls it the cost.
 
 **Three entries in this table were stale when this revision began**, and all three in the same
 direction: D3, the `changebackend` half of D8, and D11 were recorded as open and had been fixed in
@@ -194,6 +202,7 @@ has, and `scripts/wide_branch_cost.jl` is the harness.
 | D17 | **D13 was fixed on the two walks that were measured and not on the three that were not.** `mapparameters!`, `mapstorage!` and `foreachparameters` turned each *further* argument into a `values(...)` tuple per branch, and a skipped one into a fresh tuple of `nothing`s — 800 bytes a call on a flat 48-child set, 6 144 at 369, and three to four times that on a branch of branches. These are the walks an optimizer runs every iteration, where `flatten!` runs once or twice | was `src/walk.jl:152,196,293-297` | **fixed** — `_foreach_zip` reads every argument with `getfield` at a literal index; `_values_for` and `_tuple_for` are gone. Zero at every width, depth and arity. Not caught because measuring a `Vararg` method needs a zero-argument closure: `@allocated f(a, b)` lowers to `Base.allocated(f, a, b)`, whose own splat allocates |
 | D18 | **The in-place walks paired the children of two keyed branches by *position*.** `_values_for(x, ks)` ignored its `ks`, so two same-shaped sets whose keys were ordered differently wrote every leaf into the wrong parameter without a word, where `mapparameters` has always raised | was `src/walk.jl:293` | **fixed** — the generated body checks a named argument's keys against the branch's own, in the generator, so the guard is free at run time and stricter than `_check_keys`. A behaviour change: positional pairing of differently-keyed sets now raises |
 | D19 | **`scripts/wide_branch_cost.jl` still was not measuring compile time after D16.** `first_call` timed a direct `f(args...)`, and compiling `first_call` infers through that call — so the inference being timed was spent before its own `t = time()` ran. On Julia 1.13 the committed harness printed 0.00 s for every width in every column, where an opaque call measures 1.61 s for `parameterlayout` and 3.95 s for `flatten` at 369 children | was `scripts/wide_branch_cost.jl:38-42` | **fixed** — the call goes through `Base.invokelatest`. D16 and this are the same lesson from two ends: arrange the harness so the cost cannot have been paid somewhere the clock is not looking |
+| D20 | **The wide-branch tests and the sweep script measure a bare `NamedTuple`, and a consumer holds a `NetworkParameters`.** The two reach `parameterlayout` through different methods and, on Julia 1.11, cost wildly different amounts on the same leaves: 1.37 s bare against 13.44 s wrapped at 369, 2.73 s against 88.69 s at 768. So the 0.2.2 table reports the cheap column, and issue [#16](https://github.com/JuliaGNI/NeuralNetworkParameters.jl/issues/16) read the gap between the two as a cost of *nesting* — which it is not: a flat 369-leaf set and a 16 × 24 one cost the same 1.35 s bare and the same 13.8 s wrapped | was `test/wide_branch_tests.jl:27`, `scripts/wide_branch_cost.jl:32` | **fixed** — the sweep runs both shapes at every width, each in its own process, and `test/wide_branch_tests.jl` asserts the round trip and the zero allocations on the wrapped shape. No code changed: the whole path costs the same either way (21.66 s bare, 22.41 s wrapped at 369), the wrapper only decides which entry point pays, and Julia 1.12 and 1.13 do not distinguish the two at all. `src/layout.jl` records why fusing `_layout(::NetworkParameters, ::Int)` moves the cost rather than removing it |
 
 D8's two halves are the clearest evidence for the protocol, and they were fixed by different packages
 at different times. With the structured types upstream of the package that trains with them, a
@@ -296,13 +305,20 @@ Design points worth keeping in view:
 ```bash
 julia --project -e 'using Pkg; Pkg.test()'                                            # 424 tests
 julia --project=docs -e 'using Pkg; Pkg.develop(path="."); include("docs/make.jl")'   # doctests
-julia --project=. scripts/wide_branch_cost.jl                                         # D12/D13/D17
+julia --project=. scripts/wide_branch_cost.jl                                         # D12/D13/D17/D20
 ```
+
+The sweep prints two shapes at every width, bare and inside a `NetworkParameters`, each in a process of
+its own (D20). On Julia 1.11 the wrapped `layout` column has to show the cliff the bare one does not —
+about 2.2 s at 128 children and about 13.4 s at 369, against 0.66 s and 1.37 s bare. If the two columns
+agree there, the fork is warming one shape from the other and they are not in separate processes. On
+1.13 they agree because the compiler does not distinguish them.
 
 It also covers a **369-child branch** — the width of GMLDatasets' MNIST transformer, and the shape D12,
 D13 and D14 were about — through `flatten`/`unflatten`, `mapparameters` at both arities,
 `mapparameters!`, `foreachparameters` with and without the `nothing` skip, `foldparameters`, the
-`unflatten` pullback, and the in-place forms at zero allocations. It asserts the properties and not the
+`unflatten` pullback, and the in-place forms at zero allocations, and a 48-child one inside a
+`NetworkParameters` for the same round trip and the same zero allocations. It asserts the properties and not the
 timings, because a wall-clock bound would be a flake on a loaded machine; the regression test is that
 the file *completes*, which before 0.2.2 it did not. It costs the suite about 45 s on Julia 1.13 and
 about 1 m 45 s on 1.11, all of it compilation at that width, and that is the price of covering the

--- a/scripts/wide_branch_cost.jl
+++ b/scripts/wide_branch_cost.jl
@@ -1,4 +1,4 @@
-# What the walks cost as a function of the *width* of one branch.
+# What the walks cost as a function of the *width* of one branch, and of the *shape* it is held in.
 #
 # Run with the repository as the active project:
 #
@@ -23,6 +23,26 @@
 # default run is getting wrong. `GeometricOptimizers` quoted the default one — `mapparameters` at
 # "0.00 s" on a 369-entry branch, against 1.51 s measured cold — and closed an issue on it. A table is
 # cold here or it is not printed.
+#
+# **Every width is swept in both shapes: a bare `NamedTuple` and the same set inside a
+# `NetworkParameters`.** That is the same methodology applied to the argument rather than to the clock,
+# and it is worth as much. `parameterlayout` reaches a bare branch through one `@generated` body and a
+# wrapped one through `_layout(::NetworkParameters, ::Int)` first, and on Julia 1.11 those two cost
+# wildly different amounts on the same leaves: 1.37 s bare against 13.44 s wrapped at 369 children,
+# 2.73 s against 88.69 s at 768. The *whole* path costs the same either way — 21.66 s bare against
+# 22.41 s wrapped at 369, summed over `parameterlayout`, `flatten` and `unflatten` — so what the
+# wrapper changes is which entry point pays, not the total. Julia 1.12 and 1.13 do not distinguish the
+# two at all (1.78 s and 1.67 s wrapped at 369).
+#
+# A consumer holds a `NetworkParameters`, so a sweep of bare sets alone reports the cheap column and
+# calls it the cost. It reported exactly that until this shape was added, and issue #16 read the
+# difference between the two columns as a cost of *nesting*, which it is not — a flat 369-leaf set and
+# a 16 × 24 one cost the same 13.8 s wrapped and the same 1.35 s bare.
+#
+# The two shapes run in separate processes for the reason the widths do. They are different methods but
+# they share the inner `_layout(::NamedTuple, ::Int)` specialisation, so a bare row run first leaves the
+# wrapped row less to compile. On Julia 1.11 the wrapped 369 row takes about 25 s on its own account;
+# on 1.13 it takes about 5 s.
 
 using NeuralNetworkParameters
 
@@ -32,6 +52,12 @@ const T = Float32
 # in it, and a 2×2 keeps the run time next to nothing beside the compilation.
 wide_set(k::Integer) = NamedTuple{Tuple(Symbol("p", i) for i in 1:k)}(
     Tuple(fill(T(i), 2, 2) for i in 1:k))
+
+# The shape a consumer actually holds. The leaves are the same; what differs is the method
+# `parameterlayout` enters through.
+wrapped_set(k::Integer) = NetworkParameters(wide_set(k))
+
+const SHAPES = (:bare => wide_set, :wrapped => wrapped_set)
 
 # `time()` and not `@elapsed`: the point is the very first call, and `@elapsed` in a loop reports the
 # second.
@@ -68,22 +94,29 @@ _thunk_allocs(thunk) = (thunk(); thunk(); @allocated thunk())
 # walks began indexing them in place.
 _touch!(d, s) = (@inbounds d[begin] = s[begin]; nothing)
 
+# `map(zero, ·)` is the floor the other columns are read against, and it is `Base`'s function rather than
+# one of this package's — so it is measured on the `NamedTuple` in both shapes, and the wrapped column
+# reports the same figure as the bare one by construction.
+_leaves(ps::NetworkParameters) = params(ps)
+_leaves(ps) = ps
+
 # 32 is where `Base` stops unrolling a tuple; 369 is the parameter set of the MNIST transformer in
 # `scripts/geometric_optimizers/mnist.jl` of GMLDatasets.jl, which is the width that made the defect
 # worth fixing rather than noting.
 const WIDTHS = (16, 32, 48, 64, 128, 369)
 
-header() = println(rpad("children", 10), rpad("layout", 9), rpad("map(zero)", 11),
+header() = println(rpad("shape", 10), rpad("children", 10), rpad("layout", 9), rpad("map(zero)", 11),
                    rpad("mapparams", 11), rpad("flatten", 9), rpad("unflatten", 11),
                    "allocs flatten!/unflatten!/mapparameters!")
 
-# One width, in a process that has compiled nothing for it. Within the row the order still matters —
-# `flatten` builds a layout and would absorb `parameterlayout`, and `mapparameters` would absorb the
-# rest — so the rows are ordered cheapest-first and `flatten` comes after both.
-function sweep_one(k)
-    ps = wide_set(k)
+# One width in one shape, in a process that has compiled nothing for either. Within the row the order
+# still matters — `flatten` builds a layout and would absorb `parameterlayout`, and `mapparameters`
+# would absorb the rest — so the rows are ordered cheapest-first and `flatten` comes after both.
+function sweep_one(shape::Symbol, k)
+    build = last(SHAPES[findfirst(s -> first(s) === shape, SHAPES)])
+    ps = build(k)
     t_layout = first_call(parameterlayout, ps)
-    t_map = first_call(x -> map(zero, x), ps)
+    t_map = first_call(x -> map(zero, x), _leaves(ps))
     t_mapp = first_call(x -> mapparameters(zero, x), ps)
     t_flat = first_call(flatten, ps)
 
@@ -98,18 +131,24 @@ function sweep_one(k)
     a_unflat = _unflatten_allocs(dest, layout, v)
     a_mapp = _thunk_allocs(() -> mapparameters!(_touch!, dest, ps))
 
-    println(rpad(k, 10), rpad(t_layout, 9), rpad(t_map, 11), rpad(t_mapp, 11),
+    println(rpad(shape, 10), rpad(k, 10), rpad(t_layout, 9), rpad(t_map, 11), rpad(t_mapp, 11),
             rpad(t_flat, 9), rpad(t_unflat, 11), a_flat, "/", a_unflat, "/", a_mapp)
     flush(stdout)
 end
 
-# `--in-process k` is what the child processes are invoked with, and is not for interactive use.
+# `--in-process shape k` is what the child processes are invoked with, and is not for interactive use.
 function fan_out()
     header()
-    for k in WIDTHS
+    flush(stdout)
+    for (shape, _) in SHAPES, k in WIDTHS
         run(pipeline(`$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project())
-                      $(@__FILE__) --in-process $k`))
+                      $(@__FILE__) --in-process $shape $k`))
     end
 end
 
-"--in-process" in ARGS ? sweep_one(parse(Int, ARGS[findfirst(==("--in-process"), ARGS) + 1])) : fan_out()
+if "--in-process" in ARGS
+    i = findfirst(==("--in-process"), ARGS)
+    sweep_one(Symbol(ARGS[i + 1]), parse(Int, ARGS[i + 2]))
+else
+    fan_out()
+end

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -122,6 +122,33 @@ layout = parameterlayout(ps)
 """
 parameterlayout(ps) = first(_layout(ps, 0))
 
+# The container case, and **the one composition here that is deliberately left standing.**
+#
+# This is the shape the note below calls the expensive way round: a `@generated` body yielding a large
+# type, composed across a function call with a step that wraps it. It costs what that shape costs. On
+# Julia 1.11, `parameterlayout` on a flat 369-leaf set is 1.37 s as a bare `NamedTuple` and **13.44 s**
+# inside a `NetworkParameters`; at 768 leaves, 2.73 s against 88.69 s. Nesting has nothing to do with
+# it, and the arithmetic of a `NestedLayout` being a larger type than a `LeafLayout` has nothing to do
+# with it either: a 16 × 24 set of the same 384 leaves costs 1.35 s bare and 13.84 s wrapped, exactly
+# as the flat one does.
+#
+# Fusing it — one `@generated` body reading the children of `params(ps)` at literal indices and
+# building the `ParametersLayout` around them — is measured and is not what is wanted, because it
+# **moves** the cost rather than removing it. It takes `parameterlayout` from 13.59 s to 1.38 s at 369
+# wrapped and from 89.23 s to 2.81 s at 768, and puts every second of that into `flatten`: the whole
+# path — `parameterlayout`, then `flatten`, then `unflatten` — goes 22.41 s to 20.37 s, and a consumer
+# that calls only `flatten` and `unflatten` pays **twice as much**, 9.73 s against 20.73 s. The total
+# is what a consumer compiles, and the total does not depend on which method holds it: 21.66 s for the
+# bare 369 set and 22.41 s for the wrapped one.
+#
+# `@inline` here does nothing (13.67 s against 13.59 s), as `@noinline` does nothing on the branch
+# cases below. Nor is there anything to move on Julia 1.12 and 1.13, which do not distinguish the two
+# shapes: 1.78 s and 1.67 s at 369 wrapped. This is a characteristic of the compat floor and not of
+# the walk.
+#
+# A caller that wants only the size should call `flatlength`, which returns an `Int` — nothing
+# downstream of it depends on the layout type, and it costs 1.26 s here where `parameterlayout` costs
+# 13.20 s.
 function _layout(ps::NetworkParameters, offset::Int)
     inner, off = _layout(params(ps), offset)
     ParametersLayout(inner), off
@@ -137,6 +164,9 @@ end
 # into the caller's own inference, and `parameterlayout` on that set cost **11.7 s**, of which
 # the child walk alone was 0.49 s of it and the wrapping was the rest. Fused into one body, and with
 # the leaf union below removed, it is **1.36 s**.
+#
+# The container case above is that same composition, left standing on purpose. Fusing it is measured
+# too, and the note there says why it is the one place where fusing does not pay.
 #
 # Measured every way round before settling on this. A `@noinline` barrier on the child walk does not
 # help (11.78 s). Neither does supplying `NestedLayout`'s type parameters instead of letting them be
@@ -230,6 +260,12 @@ The number of entries `ps` flattens to, without allocating the flat vector.
 
 Deliberately not called `parameterlength`: `AbstractNeuralNetworks` has a function of that name for
 the parameter count of a *model*, and the two would collide on `using`.
+
+Cheaper to compile than the layout it walks, and on a large set the difference is the whole cost: this
+returns an `Int`, so nothing downstream of the call depends on the layout's type. On Julia 1.11 a
+369-leaf `NetworkParameters` costs **1.26 s** here against 13.20 s through [`parameterlayout`](@ref),
+and the figure does not move with the width or the nesting. Anything that wants only the size should
+call this; anything that has to unflatten later needs the layout and cannot.
 """
 flatlength(ps) = length(parameterlayout(ps))
 flatlength(l::ParameterLayout) = length(l)

--- a/test/wide_branch_tests.jl
+++ b/test/wide_branch_tests.jl
@@ -157,6 +157,43 @@ end
     @test counted[] > 0
 end
 
+# The same width in the shape a consumer holds it. Every other set in this file is a bare `NamedTuple`,
+# and the two are not the same measurement: a bare branch reaches `parameterlayout` through one
+# `@generated` body, a wrapped one goes through `_layout(::NetworkParameters, ::Int)` first. On Julia
+# 1.11 those cost 1.37 s and 13.44 s on the same 369 leaves. The *properties* below hold on both and are
+# what this file pins; the cost is `scripts/wide_branch_cost.jl`'s business, and it sweeps both shapes at
+# every width for exactly this reason.
+#
+# 48 and not 369, for the reason the nesting testset gives: nothing here depends on the width once the
+# width is past the unrolling boundary, and a wrapped 369 would cost the suite the better part of half a
+# minute on the compat floor to say what the 48 already says.
+wrapped_set(k) = NetworkParameters(wide_set(k))
+
+@testset "a wide NetworkParameters round-trips and does not allocate at $k children" for k in (48,)
+    ps = wrapped_set(k)
+    v, layout = flatten(ps)
+
+    @test length(v) == 4k
+    @test flatlength(ps) == 4k
+    @test unflatten(layout, v) isa NetworkParameters
+    @test unflatten(layout, v) == ps
+    @test mapparameters(x -> 2x, ps).p1 == 2 * ps.p1
+
+    buf = similar(v)
+    dest = unflatten(layout, zero(v))
+    _flatten_allocs(buf, ps, layout)          # warm up the call and the measurement
+    _unflatten_allocs(dest, layout, v)
+    @test _flatten_allocs(buf, ps, layout) == 0
+    @test _unflatten_allocs(dest, layout, v) == 0
+
+    # the two-set walks too: the wrapper is one more level for them to index in place
+    counted = Ref(0)
+    bump2(_, _) = (counted[] += 1; nothing)
+    @test _thunk_allocs(() -> mapparameters!(bump2, dest, ps)) == 0
+    @test _thunk_allocs(() -> mapstorage!(bump2, dest, ps)) == 0
+    @test counted[] > 0
+end
+
 @testset "a wide branch is a ParameterSet and a parameter tree" begin
     ps = wide_set(369)
     @test ps isa ParameterSet


### PR DESCRIPTION
Closes the investigation behind #16, which is closed as not a defect.

`parameterlayout` is not superlinear in the leaf count of a *nested* set. Re-measured on `af3703e`
(0.2.2), cold, one process per figure, through `Base.invokelatest`, Julia 1.11.9 on the machine the
issue used, the nested column does not reproduce and the comparison behind it is confounded: **its
flat baseline row is a bare `NamedTuple` and its nested rows are a `NetworkParameters`.** Nesting is
not the variable. The wrapper is.

`src/layout.jl` is byte-identical between `fccb2c3`, the commit #16 was measured on, and `HEAD`, so
nothing merged since can have moved its numbers.

### `parameterlayout`, first call, Julia 1.11.9

| leaves | shape | bare `NamedTuple` | in `NetworkParameters` | as #16 reports |
|---|---|---|---|---|
| 128 | 16 × 8 | 0.67 | 2.48 | 2.52 |
| 256 | 16 × 16 | 0.96 | 5.07 | 5.02 |
| **369** | **flat** | **1.37** | **13.44** | **1.35** |
| 384 | 16 × 24 | 1.35 | 13.84 | 13.91 |
| 384 | 32 × 12 | 1.37 | 13.68 | 14.71 |
| **768** | **flat** | **2.73** | **88.69** | — |
| 768 | 32 × 24 | 2.45 | — | 80.6 |

369 leaves with no nesting at all cost 13.44 s wrapped and 1.37 s bare, so the whole 10× gap is that
one column change. Bare, the walk is near-linear in the leaf count and a nested set costs what a flat
one of the same size costs — which is what `_layout` was rewritten in 0.2.2 to achieve.

The wrapper does not add to the *total*; it decides which entry point pays. Whole cold path,
`parameterlayout` then `flatten` then `unflatten`, 1.11.9: 16 × 24 is `1.37 + 13.40 + 0.43 = 15.20`
bare against `14.35 + 0.94 + 0.46 = 15.75` wrapped, and flat 369 is 21.66 s against 22.41 s. And it
is the compat floor's rather than the walk's — wrapped `parameterlayout` at flat 369 is
`13.44 → 1.78 → 1.67` on 1.11.9 / 1.12.7 / 1.13.0-rc3, and at flat 768 `88.69 → 3.82 → 5.23`.

## D20 — the tests and the sweep measure a shape nobody holds

`wide_set` and `nested_set` in `test/wide_branch_tests.jl` and `wide_set` in
`scripts/wide_branch_cost.jl` all build a bare `NamedTuple`; a consumer holds a `NetworkParameters`.
So the committed table reports the cheap column and calls it the cost, which is why the 0.2.2
CHANGELOG can say 1.35 s at 369 children and #16 can say 13.9 s and both be right about different
shapes. D16 and D19 were that lesson about the clock; this is it about the argument.

- **`scripts/wide_branch_cost.jl` sweeps both shapes at every width**, each in a process of its own.
  They are different methods but share the inner `_layout(::NamedTuple, ::Int)` specialisation, so a
  bare row run first leaves the wrapped row less to compile — the trap D16 was.
- **`test/wide_branch_tests.jl` asserts the round trip and the zero allocations on a wrapped
  48-child set.** 48 and not 369 for the reason the nesting testset gives: what this file pins is the
  property, the properties do not depend on the width past the unrolling boundary, and a wrapped 369
  would cost the suite half a minute on the compat floor to say nothing the 48 does not. The cost is
  the sweep's business.
- **`PLAN.md`** records D20 and the check the sweep is now for; **`CHANGELOG.md`** qualifies the
  0.2.2 `parameterlayout` column, which is the thing that made #16 possible.

The sweep on 1.11 shows the split it exists to show, and 1.13 shows the two columns agreeing:

```
shape     children  layout   map(zero)  mapparams  flatten  unflatten  allocs
bare      128       0.68     0.01       0.03       2.08     1.12       0/0/0
bare      369       1.32     0.01       0.04       13.87    4.25       0/0/0
wrapped   128       2.32     0.01       0.04       0.77     1.12       0/0/0
wrapped   369       13.77    0.01       0.04       4.22     4.54       0/0/0
```

## No package code changed, and `src/layout.jl` records why

`_layout(::NetworkParameters, ::Int)` is the compose-across-a-function-call shape that the note on
the two branch cases calls the expensive way round. Fusing it into one `@generated` body was
measured: `parameterlayout` goes 13.59 → **1.38 s** at 369 wrapped and 89.23 → **2.81 s** at 768. It
**moves** the cost rather than removing it — the whole path goes 22.41 → 20.37 s, and a consumer that
calls only `flatten`/`unflatten` pays **twice as much**, 9.73 → 20.73 s. `@inline` there does nothing
(13.67 against 13.59), as `@noinline` does nothing on the branch cases, and 1.12 and 1.13 have
nothing to move. The note above the method carries all of it so it is not tried again.

## The two proposals in #16

**"Worth doing meanwhile" reproduces and was already shipped.** `flatlength` costs **1.26 s** against
`parameterlayout`'s 13.20 s on the wrapped flat 369, and 1.28 s on the *bare* 16 × 24 too — the same
on every shape and every wrapping. Its docstring says so now; that is the whole change.

**"Untested idea" — a width split keyed on whether a branch's children are branches — needs no test.**
The worst case measured, a flat 768-leaf set inside a `NetworkParameters` at 88.69 s, has no branch
whose children are branches, so the key never fires; and the shape the idea targets is already linear
and already equal to a flat branch of the same leaf count (0.66 / 0.96 / 1.35 / 1.68 / 2.45 s at
128 / 256 / 384 / 512 / 768 leaves).

## Verification

```
julia +1.11 --project=. -e 'using Pkg; Pkg.test()'      # 434 tests, wide branches 1m45s
julia +1.13 --project=. -e 'using Pkg; Pkg.test()'      # 434 tests, wide branches 39s
julia +1.11 --project=. scripts/wide_branch_cost.jl     # both shapes, one process each
julia +1.13 --project=. scripts/wide_branch_cost.jl
julia +1.11 --project=docs docs/make.jl                 # doctests
```

434 tests green on 1.11 and 1.13; doctests and cross-references green. The wide-branch suite costs the
same as before — the wrapped 48-child testset adds nothing measurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
