### PR TITLE
Take the leaf's array type out of the layout it lands in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,80 @@ Notable changes to `NeuralNetworkParameters` are recorded here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The package follows
 [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] — 2026-08-26
+
+**The cost of a wrapped parameter set was one unused type parameter.** 0.2.2 made a wide branch
+compilable and left one shape standing that was not: `parameterlayout` on a 369-leaf set cost 1.35 s as
+a bare `NamedTuple` and 13.50 s inside a `NetworkParameters`, and at 768 leaves 2.76 s against 86.88 s.
+The gap was read as a cost of the composition in `_layout(::NetworkParameters, ::Int)`, and issue #16
+read it as a cost of *nesting*. It was neither, and the note in `src/layout.jl` that argued the first
+of those is corrected here rather than released — it was written after the 0.2.2 bump and this is its
+first release.
+
+### Removed
+
+- **`LeafLayout` no longer carries a `prototype`.** The field was written at construction and read
+  nowhere: a `LeafLayout` is by construction the case where `freeparameters(x) === x`, so `rebuild` on
+  it is the identity and is never called. The two prototypes the package does read are both on
+  `WrappedLayout`, where unflattening genuinely rebuilds against one. The struct is now
+  `LeafLayout{N}` over `range` and `size`, which is what every method dispatching on it already read
+  and what `==` already compared.
+
+  The layouts are not exported and are built by `parameterlayout` rather than by hand, which is why
+  this is a patch. A caller who did construct one directly has to drop the third argument:
+  `LeafLayout(range, size, prototype)` becomes `LeafLayout(range, size)`. Nothing in
+  `AbstractNeuralNetworks`, `SymbolicNeuralNetworks`, `GeometricOptimizers` or
+  `GeometricMachineLearning` does — they dispatch on the bare type and read `size`.
+
+  A layout also no longer holds a live reference to each leaf array, so keeping one no longer keeps the
+  parameter set it was built from alive. `Base.summarysize` of the layout of a one-leaf set is 48 bytes
+  whether that leaf is 2 × 2 or 1000 × 1000.
+
+### Fixed
+
+- **`parameterlayout` on a `NetworkParameters` costs what it costs on the `NamedTuple` inside it.** The
+  type parameter above was the leaf's concrete array type, so it went into the layout type of every
+  branch above that leaf — 1849 nodes in the type tree of a 369-leaf wrapped layout, against 742
+  without it. `_layout(::NetworkParameters, ::Int)` is where a caller paid for that, because it infers
+  through the child walk's whole return type to reach `ParametersLayout(inner)`, and inference on such a
+  type grows faster than the type does: 2.5 times the type was 13 times the time.
+
+  First call, Julia 1.11, one process per row, `scripts/leaf_layout_cost.jl`:
+
+  | `parameterlayout` on | 0.2.2 | 0.2.3 | type nodes |
+  |---|---|---|---|
+  | 369 leaves, bare `NamedTuple` | 1.35 s | 1.04 s | 1848 → 741 |
+  | 369 leaves, in a `NetworkParameters` | 13.40 s | **1.05 s** | 1849 → 742 |
+  | 768 leaves, bare | 2.77 s | 3.07 s | 3843 → 1539 |
+  | 768 leaves, in a `NetworkParameters` | 87.77 s | **3.01 s** | 3844 → 1540 |
+  | 16 × 24 nested, bare | 1.46 s | 0.85 s | 1971 → 819 |
+  | 16 × 24 nested, in a `NetworkParameters` | 14.00 s | **0.84 s** | 1972 → 820 |
+
+  **The bare column is where to look, and it does not improve** — at 768 leaves it is a shade slower,
+  2.77 s against 3.07 s, and 2.76 s against 2.99 s on a second run, which is the run-to-run spread of a
+  single cold measurement rather than a regression. The type shrinks by 2.5× in that column too, and
+  buys nothing there. What was expensive was never the walk; it was what a caller had to infer through
+  to wrap the walk's result, and only the wrapped column has such a caller.
+
+  Neither the width nor the nesting drives it either: 768 flat leaves now cost less than half what 369
+  wrapped ones used to, and 384 leaves in 16 branches cost slightly less than 369 in one.
+
+  `flatten` improves with it, 14.38 s to 3.61 s on the bare 369 set, and the whole path —
+  `parameterlayout`, then `flatten`, then `unflatten` — goes from 21.90 s to **8.64 s** on the wrapped
+  one. Those and the allocation figures are `scripts/wide_branch_cost.jl`, whose 24 rows all still read
+  zero; 0.2.1's guarantees are the reason that had to be checked rather than assumed.
+
+  Julia 1.11, 1.12 and 1.13 now agree at 1.05 s, 1.13 s and 1.03 s on the wrapped 369 set. The compat
+  floor used to be the version that behaved differently, and the note in `src/layout.jl` that called
+  that "a characteristic of the compat floor and not of the walk" was wrong: it was a characteristic of
+  the layout type, which 1.12 and 1.13 were better at absorbing.
+
+  Issue #15 filed this as hygiene and said explicitly that it was not the cause of the nested-layout
+  compile cost, on the evidence that alternating `Matrix`/`Vector` leaves cost 11.32 s against 13.9 s
+  homogeneous. That measurement is sound and its conclusion — that leaf *diversity* is not the driver —
+  still holds. It compared two sets under the old layout type, though, and never compared the layout
+  type with and without the parameter, which is where the 13× was.
+
 ## [0.2.2] — 2026-08-25
 
 **A branch with many children is usable.** 0.2.1 finished making the walks type stable and allocation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ Notable changes to `NeuralNetworkParameters` are recorded here, following
 
 **The cost of a wrapped parameter set was one unused type parameter.** 0.2.2 made a wide branch
 compilable and left one shape standing that was not: `parameterlayout` on a 369-leaf set cost 1.35 s as
-a bare `NamedTuple` and 13.50 s inside a `NetworkParameters`, and at 768 leaves 2.76 s against 86.88 s.
-The gap was read as a cost of the composition in `_layout(::NetworkParameters, ::Int)`, and issue #16
-read it as a cost of *nesting*. It was neither, and the note in `src/layout.jl` that argued the first
-of those is corrected here rather than released — it was written after the 0.2.2 bump and this is its
-first release.
+a bare `NamedTuple` and 13.40 s inside a `NetworkParameters`, and at 768 leaves 2.77 s against 87.77 s.
+Those four are the table below, which is where the entry's figures come from unless it names another
+harness or another run. The gap was read as a cost of the composition in
+`_layout(::NetworkParameters, ::Int)`, and issue [#16] read it as a cost of *nesting*. It was neither,
+and the note in `src/layout.jl` that argued the first of those is corrected here rather than released —
+it was written after the 0.2.2 bump and this is its first release.
 
 ### Removed
 
@@ -29,9 +30,12 @@ first release.
   `AbstractNeuralNetworks`, `SymbolicNeuralNetworks`, `GeometricOptimizers` or
   `GeometricMachineLearning` does — they dispatch on the bare type and read `size`.
 
-  A layout also no longer holds a live reference to each leaf array, so keeping one no longer keeps the
-  parameter set it was built from alive. `Base.summarysize` of the layout of a one-leaf set is 48 bytes
-  whether that leaf is 2 × 2 or 1000 × 1000.
+  A terminal leaf's layout also no longer holds a live reference to the array, so keeping one no longer
+  keeps that leaf alive. `Base.summarysize` of the layout of a one-leaf set is 48 bytes whether the
+  leaf is 2 × 2 or 1000 × 1000, and `test/layout_tests.jl` pins it. A *structured* leaf is unchanged
+  and stays that way: its `WrappedLayout` holds the prototype `rebuild` unflattens against, so a set
+  with a `SymmetricMatrix` or a manifold element in it still has those leaves reachable from its
+  layout.
 
 ### Fixed
 
@@ -72,11 +76,11 @@ first release.
   that "a characteristic of the compat floor and not of the walk" was wrong: it was a characteristic of
   the layout type, which 1.12 and 1.13 were better at absorbing.
 
-  Issue #15 filed this as hygiene and said explicitly that it was not the cause of the nested-layout
+  Issue [#15] filed this as hygiene and said explicitly that it was not the cause of the nested-layout
   compile cost, on the evidence that alternating `Matrix`/`Vector` leaves cost 11.32 s against 13.9 s
   homogeneous. That measurement is sound and its conclusion — that leaf *diversity* is not the driver —
   still holds. It compared two sets under the old layout type, though, and never compared the layout
-  type with and without the parameter, which is where the 13× was.
+  type with and without the parameter, which is where the 13× was ([#18]).
 
 ## [0.2.2] — 2026-08-25
 
@@ -538,6 +542,11 @@ The initial release: the `NetworkParameters` container and its flat `FlatParamet
 [#11]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/pull/11
 [#12]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/pull/12
 [#13]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/pull/13
+[#15]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/issues/15
+[#16]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/issues/16
+[#18]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/pull/18
+[0.2.3]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.2.3
+[0.2.2]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.2.2
 [0.2.1]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.2.1
 [0.2.0]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.2.0
 [0.1.1]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.1.1

--- a/PLAN.md
+++ b/PLAN.md
@@ -151,8 +151,8 @@ checkouts, so §8 is now written as *where each package stands* rather than as a
 ## 4. Defects on record
 
 D1, D2, D3, D4, D7, D8, D9, D10, D11, D12, D13 and D14 are fixed — which is all of them but D5 and
-D6, and those two are open *in `GeometricOptimizers`* rather than here. D15 through D20 are new in this
-revision and are all six defects of this package's own 0.2.2 work, found by running it rather than by
+D6, and those two are open *in `GeometricOptimizers`* rather than here. D15 through D21 are new in this
+revision and are all seven defects of this package's own 0.2.2 work, found by running it rather than by
 reading it.
 
 **D17 and D18 came from reviewing 0.2.2 itself**, and the lesson is narrower than D16's and worth as
@@ -164,9 +164,16 @@ guarantee holds where it is asserted and nowhere else.
 swept its widths in one process, so every row but the first measured what its predecessors had
 compiled. D19 timed a direct call, so the inference being timed was spent before the clock started.
 D20 is the argument rather than the clock — every set the sweep and the wide-branch tests build is a
-bare `NamedTuple`, and a consumer holds a `NetworkParameters`. On Julia 1.11 that is 1.37 s against
-13.44 s for `parameterlayout` on the same 369 leaves, so the committed table reports the cheap column
+bare `NamedTuple`, and a consumer holds a `NetworkParameters`. On Julia 1.11 that is 1.35 s against
+13.40 s for `parameterlayout` on the same 369 leaves, so the committed table reports the cheap column
 and calls it the cost.
+
+**D21 is the fourth side, and it is what the other three are for.** Pointing the harness at the shape
+a consumer holds is what made a 13× gap visible; D20 then closed on the gap as a property of the two
+entry points, because the bare column looked healthy and nothing in it moved. It was one unused type
+parameter, and the bare column could not have shown it — only the wrapped path has a caller that has
+to infer through the layout type. A two-column sweep earns its keep by making a difference visible,
+not by explaining it, and D20 stopped a step early.
 
 **Three entries in this table were stale when this revision began**, and all three in the same
 direction: D3, the `changebackend` half of D8, and D11 were recorded as open and had been fixed in
@@ -202,7 +209,8 @@ has, and `scripts/wide_branch_cost.jl` is the harness.
 | D17 | **D13 was fixed on the two walks that were measured and not on the three that were not.** `mapparameters!`, `mapstorage!` and `foreachparameters` turned each *further* argument into a `values(...)` tuple per branch, and a skipped one into a fresh tuple of `nothing`s — 800 bytes a call on a flat 48-child set, 6 144 at 369, and three to four times that on a branch of branches. These are the walks an optimizer runs every iteration, where `flatten!` runs once or twice | was `src/walk.jl:152,196,293-297` | **fixed** — `_foreach_zip` reads every argument with `getfield` at a literal index; `_values_for` and `_tuple_for` are gone. Zero at every width, depth and arity. Not caught because measuring a `Vararg` method needs a zero-argument closure: `@allocated f(a, b)` lowers to `Base.allocated(f, a, b)`, whose own splat allocates |
 | D18 | **The in-place walks paired the children of two keyed branches by *position*.** `_values_for(x, ks)` ignored its `ks`, so two same-shaped sets whose keys were ordered differently wrote every leaf into the wrong parameter without a word, where `mapparameters` has always raised | was `src/walk.jl:293` | **fixed** — the generated body checks a named argument's keys against the branch's own, in the generator, so the guard is free at run time and stricter than `_check_keys`. A behaviour change: positional pairing of differently-keyed sets now raises |
 | D19 | **`scripts/wide_branch_cost.jl` still was not measuring compile time after D16.** `first_call` timed a direct `f(args...)`, and compiling `first_call` infers through that call — so the inference being timed was spent before its own `t = time()` ran. On Julia 1.13 the committed harness printed 0.00 s for every width in every column, where an opaque call measures 1.61 s for `parameterlayout` and 3.95 s for `flatten` at 369 children | was `scripts/wide_branch_cost.jl:38-42` | **fixed** — the call goes through `Base.invokelatest`. D16 and this are the same lesson from two ends: arrange the harness so the cost cannot have been paid somewhere the clock is not looking |
-| D20 | **The wide-branch tests and the sweep script measure a bare `NamedTuple`, and a consumer holds a `NetworkParameters`.** The two reach `parameterlayout` through different methods and, on Julia 1.11, cost wildly different amounts on the same leaves: 1.37 s bare against 13.44 s wrapped at 369, 2.73 s against 88.69 s at 768. So the 0.2.2 table reports the cheap column, and issue [#16](https://github.com/JuliaGNI/NeuralNetworkParameters.jl/issues/16) read the gap between the two as a cost of *nesting* — which it is not: a flat 369-leaf set and a 16 × 24 one cost the same 1.35 s bare and the same 13.8 s wrapped | was `test/wide_branch_tests.jl:27`, `scripts/wide_branch_cost.jl:32` | **fixed** — the sweep runs both shapes at every width, each in its own process, and `test/wide_branch_tests.jl` asserts the round trip and the zero allocations on the wrapped shape. No code changed: the whole path costs the same either way (21.66 s bare, 22.41 s wrapped at 369), the wrapper only decides which entry point pays, and Julia 1.12 and 1.13 do not distinguish the two at all. `src/layout.jl` records why fusing `_layout(::NetworkParameters, ::Int)` moves the cost rather than removing it |
+| D20 | **The wide-branch tests and the sweep script measure a bare `NamedTuple`, and a consumer holds a `NetworkParameters`.** The two reach `parameterlayout` through different methods and, on Julia 1.11, cost wildly different amounts on the same leaves: 1.35 s bare against 13.40 s wrapped at 369, 2.77 s against 87.77 s at 768. So the 0.2.2 table reports the cheap column, and issue [#16](https://github.com/JuliaGNI/NeuralNetworkParameters.jl/issues/16) read the gap between the two as a cost of *nesting* — which it is not: a flat 369-leaf set and a 16 × 24 one cost the same 1.35 s bare and the same 13.8 s wrapped | was `test/wide_branch_tests.jl:27`, `scripts/wide_branch_cost.jl:32` | **fixed** — the sweep runs both shapes at every width, each in its own process, and `test/wide_branch_tests.jl` asserts the round trip and the zero allocations on the wrapped shape. This entry closed on the measurement without a cause, and recorded that no code needed to change on the grounds that the whole path cost nearly the same either way (19.96 s bare, 21.90 s wrapped at 369) so the wrapper only decided which entry point paid. **That was where to look and not what to conclude**: the gap had a cause, D21 is it, and 0.2.3 removed it. The two columns agree now |
+| D21 | **`LeafLayout` carried a `prototype` field that nothing read, and it was the cost D20 measured.** A `LeafLayout` is by construction the terminal case, so `rebuild` on it is the identity and is never called — but the field's type parameter put each leaf's *concrete array type* into the layout type of every branch above it, 1849 nodes in the type tree of a 369-leaf wrapped layout against 742 without. `_layout(::NetworkParameters, ::Int)` is where a caller paid for it, inferring through the child walk's whole return type to wrap its result, and inference on such a type grows faster than the type does: 2.5 times the type was 13 times the time. The bare column never showed it, because only the wrapped shape has such a caller — which is exactly why D20's two-column sweep was needed to find it and D20's own conclusion was not | was `src/layout.jl:29` | **fixed, 0.2.3** — the struct is `LeafLayout{N}` over `range` and `size`. `parameterlayout` on a 369-leaf set inside a `NetworkParameters` goes 13.40 s → 1.05 s and at 768 leaves 87.77 s → 3.01 s, the whole 369-wrapped path 21.90 s → 8.64 s, and Julia 1.11, 1.12 and 1.13 agree at 1.05/1.13/1.03 s where the compat floor used to be the one that behaved differently. `scripts/leaf_layout_cost.jl` is the harness. Issue [#15](https://github.com/JuliaGNI/NeuralNetworkParameters.jl/issues/15) filed it as hygiene and said explicitly it was not the cause: it had compared two leaf *sets* under one layout type, never the layout type with and without the parameter |
 
 D8's two halves are the clearest evidence for the protocol, and they were fixed by different packages
 at different times. With the structured types upstream of the package that trains with them, a
@@ -303,16 +311,23 @@ Design points worth keeping in view:
 ### Verification
 
 ```bash
-julia --project -e 'using Pkg; Pkg.test()'                                            # 424 tests
+julia --project -e 'using Pkg; Pkg.test()'                                            # 440 tests
 julia --project=docs -e 'using Pkg; Pkg.develop(path="."); include("docs/make.jl")'   # doctests
 julia --project=. scripts/wide_branch_cost.jl                                         # D12/D13/D17/D20
+julia --project=. scripts/leaf_layout_cost.jl                                         # D21
 ```
 
 The sweep prints two shapes at every width, bare and inside a `NetworkParameters`, each in a process of
-its own (D20). On Julia 1.11 the wrapped `layout` column has to show the cliff the bare one does not —
-about 2.2 s at 128 children and about 13.4 s at 369, against 0.66 s and 1.37 s bare. If the two columns
-agree there, the fork is warming one shape from the other and they are not in separate processes. On
-1.13 they agree because the compiler does not distinguish them.
+its own (D20). **The two `layout` columns now agree on every Julia — about 1.05 s wrapped against 1.04 s
+bare at 369 children — and that is the reading rather than a warning.** Until 0.2.3 the wrapped column
+showed a cliff the bare one did not, about 13.4 s at 369 on Julia 1.11, and D21 is what that was. A
+cliff re-appearing there is the regression to act on.
+
+That leaves the fork itself to be checked some other way, since agreeing columns no longer distinguish
+a working fan-out from a broken one. Check it directly: `fan_out` `run`s one child process per row and
+each prints its own line, so `ps aux` during a run, or simply invoking one row on its own —
+`julia --project=. scripts/wide_branch_cost.jl --in-process wrapped 369` — is what says the isolation
+holds. A row run alone and the same row inside the sweep have to read the same.
 
 It also covers a **369-child branch** — the width of GMLDatasets' MNIST transformer, and the shape D12,
 D13 and D14 were about — through `flatten`/`unflatten`, `mapparameters` at both arities,

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralNetworkParameters"
 uuid = "67f4d93a-60e9-472b-8cdd-1ccf6005724a"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Michael Kraus <michael.kraus@ipp.mpg.de> and contributors"]
 
 [deps]

--- a/scripts/leaf_layout_cost.jl
+++ b/scripts/leaf_layout_cost.jl
@@ -31,10 +31,16 @@ const T = Float32
 # than a detail: compiling this function would otherwise infer through the call in its body, so the
 # cost would be spent before the clock starts and every row would read 0.00 s. `wide_branch_cost.jl`
 # read exactly that on Julia 1.13 until it was written this way.
+#
+# The **value** comes back with the time for the same reason. The caller wants the layout's type as
+# well as the clock, and reaching for it with a second, direct `parameterlayout(ps)` would put an
+# inferable call to the timed function in the caller's own body — where its cost is paid while the
+# caller compiles, before `t = time()` ever runs. That the union `ps` infers to happens to be too
+# wide for Julia to split is not a guard; handing the value back is.
 function first_call(f, args...)
     t = time()
-    Base.invokelatest(f, args...)
-    round(time() - t; digits = 2)
+    x = Base.invokelatest(f, args...)
+    round(time() - t; digits = 2), x
 end
 
 # All leaves the same tiny matrix: this measures the shape a layout is held in, not the size of the
@@ -65,9 +71,9 @@ const CASES = (
 function run_one(case::Int, wrapped::Bool)
     name, build = CASES[case]
     ps = wrapped ? NetworkParameters(build()) : build()
-    t = first_call(parameterlayout, ps)
+    t, layout = first_call(parameterlayout, ps)
     println(rpad(name, 18), rpad(wrapped ? "wrapped" : "bare", 10), rpad(t, 8),
-        type_nodes(typeof(parameterlayout(ps))))
+        type_nodes(typeof(layout)))
     flush(stdout)
 end
 

--- a/scripts/leaf_layout_cost.jl
+++ b/scripts/leaf_layout_cost.jl
@@ -1,0 +1,88 @@
+# What `parameterlayout` costs in each of the two shapes a caller can hold it in, at the two widths and
+# the one nested set the 0.2.3 CHANGELOG entry quotes.
+#
+# Run with the repository as the active project:
+#
+#     julia --project=. scripts/leaf_layout_cost.jl
+#
+# This is the harness behind that entry's table, committed for the reason `wide_branch_cost.jl` is: a
+# number is reproducible only where the code that produced it is. The two scripts overlap at 369 leaves
+# and are kept apart because they answer different questions. That one sweeps the *width* of one branch
+# across the whole walk — `flatten`, `unflatten`, `mapparameters`, and the allocation ceilings with
+# them — and stops at 369 because that is the parameter set that made the 0.2.2 defect worth fixing.
+# This one holds the walk fixed and varies only what a layout is *held in*, because that is where the
+# cost 0.2.3 removed actually lived, and it reaches 768 leaves and a nested set to show that neither the
+# width nor the nesting is what drives it.
+#
+# **Every row runs in a process of its own**, for the reason that script's header gives at length:
+# compilation is shared across a session, so a row that runs second is measuring what the first already
+# paid for. There is nothing to interleave here — every row calls the same function — which makes the
+# hazard worse rather than better.
+#
+# The figures in the CHANGELOG were taken on Julia 1.11, which is the compat floor and was the version
+# that behaved differently before this release. Pass another with `julia +1.12` and so on; 1.11, 1.12
+# and 1.13 now agree to within a tenth of a second on the wrapped 369 row.
+
+using NeuralNetworkParameters
+
+const T = Float32
+
+# `time()` and `invokelatest`, not `@elapsed` and a direct call, and that is the measurement rather
+# than a detail: compiling this function would otherwise infer through the call in its body, so the
+# cost would be spent before the clock starts and every row would read 0.00 s. `wide_branch_cost.jl`
+# read exactly that on Julia 1.13 until it was written this way.
+function first_call(f, args...)
+    t = time()
+    Base.invokelatest(f, args...)
+    round(time() - t; digits = 2)
+end
+
+# All leaves the same tiny matrix: this measures the shape a layout is held in, not the size of the
+# arrays in it, and a 2×2 keeps the run time next to nothing beside the compilation.
+flat_set(k::Integer) = NamedTuple{Tuple(Symbol("p", i) for i in 1:k)}(
+    Tuple(fill(T(i), 2, 2) for i in 1:k))
+
+# The keys differ per branch, so the 16 branches are 16 distinct `NamedTuple` types rather than one
+# compiled once and reused. A nested set whose branches share a type costs a fraction of this and would
+# make the nesting look free for the wrong reason.
+branch(j::Integer, k::Integer) = NamedTuple{Tuple(Symbol("L", j, "p", i) for i in 1:k)}(
+    Tuple(fill(T(i), 2, 2) for i in 1:k))
+
+nested_set(o::Integer, k::Integer) = NamedTuple{Tuple(Symbol("L", j) for j in 1:o)}(
+    Tuple(branch(j, k) for j in 1:o))
+
+# Nodes in the type tree of the layout, which is the quantity the entry's "2.5 times the type" is.
+# `length(string(T))` cannot be used for it: Julia elides long types when printing, so a 369-child
+# layout prints at about seven characters per child whether or not the leaves' array types are in it.
+type_nodes(x) = x isa DataType ? 1 + sum(type_nodes(p) for p in x.parameters; init = 0) : 1
+
+const CASES = (
+    ("369 leaves, flat", () -> flat_set(369)),
+    ("768 leaves, flat", () -> flat_set(768)),
+    ("16 × 24 nested", () -> nested_set(16, 24))
+)
+
+function run_one(case::Int, wrapped::Bool)
+    name, build = CASES[case]
+    ps = wrapped ? NetworkParameters(build()) : build()
+    t = first_call(parameterlayout, ps)
+    println(rpad(name, 18), rpad(wrapped ? "wrapped" : "bare", 10), rpad(t, 8),
+        type_nodes(typeof(parameterlayout(ps))))
+    flush(stdout)
+end
+
+function fan_out()
+    println(rpad("set", 18), rpad("held in", 10), rpad("layout", 8), "type nodes")
+    flush(stdout)
+    for case in eachindex(CASES), wrapped in (false, true)
+        run(pipeline(`$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project())
+                      $(@__FILE__) --in-process $case $wrapped`))
+    end
+end
+
+if "--in-process" in ARGS
+    i = findfirst(==("--in-process"), ARGS)
+    run_one(parse(Int, ARGS[i + 1]), parse(Bool, ARGS[i + 2]))
+else
+    fan_out()
+end

--- a/scripts/wide_branch_cost.jl
+++ b/scripts/wide_branch_cost.jl
@@ -27,19 +27,22 @@
 # **Every width is swept in both shapes: a bare `NamedTuple` and the same set inside a
 # `NetworkParameters`.** That is the same methodology applied to the argument rather than to the clock,
 # and it is worth as much. `parameterlayout` reaches a bare branch through one `@generated` body and a
-# wrapped one through `_layout(::NetworkParameters, ::Int)` first, and until 0.2.3 those two cost wildly
-# different amounts on the same leaves: on Julia 1.11, 1.35 s bare against 13.50 s wrapped at 369
-# children, and 2.77 s against 87.77 s at 768 through `scripts/leaf_layout_cost.jl`, which reaches that
-# width. The *whole* path cost nearly the same either way — 19.96 s
-# bare against 21.90 s wrapped at 369, summed over `parameterlayout`, `flatten` and `unflatten` — so
-# what the wrapper changed was which entry point paid, not the total.
+# wrapped one through `_layout(::NetworkParameters, ::Int)` first, and until 0.2.3 those two cost
+# wildly different amounts on the same leaves: on Julia 1.11, 1.35 s bare against 13.50 s wrapped at
+# 369 children, and 2.77 s against 87.77 s at 768 through `scripts/leaf_layout_cost.jl`, which reaches
+# that width. The *whole* path cost nearly the same either way — 19.96 s bare against 21.90 s wrapped
+# at 369, summed over `parameterlayout`, `flatten` and `unflatten` — so what the wrapper changed was
+# which entry point paid, not the total.
 #
 # That is how this sweep found what 0.2.3 removed. The gap was not a cost of the wrapper, and issue #16
 # was right that it was not a cost of nesting either: it was `LeafLayout`'s `prototype` type parameter,
 # which put every leaf's concrete array type into the layout type this method's caller infers through.
-# The two columns now agree — 1.05 s wrapped against 1.04 s bare at 369, 3.01 s against 3.07 s at 768,
-# 0.84 s against 0.85 s on a 16 × 24 set of the same 384 leaves — and the whole 369-wrapped path is
-# 8.64 s. The rows past 369 and the nested one are `scripts/leaf_layout_cost.jl`.
+# The two columns now agree, and `scripts/leaf_layout_cost.jl` is where every figure in this paragraph
+# is from — 1.05 s wrapped against 1.04 s bare at 369, 3.01 s against 3.07 s at 768, 0.84 s against
+# 0.85 s on a 16 × 24 set of the same 384 leaves — with the whole 369-wrapped path at 8.64 s. That
+# script is the one that reaches past 369 and the one that varies the nesting; read its 369 row against
+# this one's the way its 13.40 s reads against the 13.50 s above, a tenth of a second apart.
+#
 # Both shapes are still swept, for two reasons: a consumer holds a `NetworkParameters`, so a sweep of
 # bare sets alone would report a shape nobody has, and two columns that agree are how the asymmetry
 # coming back would be noticed.

--- a/scripts/wide_branch_cost.jl
+++ b/scripts/wide_branch_cost.jl
@@ -27,22 +27,27 @@
 # **Every width is swept in both shapes: a bare `NamedTuple` and the same set inside a
 # `NetworkParameters`.** That is the same methodology applied to the argument rather than to the clock,
 # and it is worth as much. `parameterlayout` reaches a bare branch through one `@generated` body and a
-# wrapped one through `_layout(::NetworkParameters, ::Int)` first, and on Julia 1.11 those two cost
-# wildly different amounts on the same leaves: 1.37 s bare against 13.44 s wrapped at 369 children,
-# 2.73 s against 88.69 s at 768. The *whole* path costs the same either way — 21.66 s bare against
-# 22.41 s wrapped at 369, summed over `parameterlayout`, `flatten` and `unflatten` — so what the
-# wrapper changes is which entry point pays, not the total. Julia 1.12 and 1.13 do not distinguish the
-# two at all (1.78 s and 1.67 s wrapped at 369).
+# wrapped one through `_layout(::NetworkParameters, ::Int)` first, and until 0.2.3 those two cost wildly
+# different amounts on the same leaves: on Julia 1.11, 1.35 s bare against 13.50 s wrapped at 369
+# children, and 2.77 s against 87.77 s at 768 through `scripts/leaf_layout_cost.jl`, which reaches that
+# width. The *whole* path cost nearly the same either way — 19.96 s
+# bare against 21.90 s wrapped at 369, summed over `parameterlayout`, `flatten` and `unflatten` — so
+# what the wrapper changed was which entry point paid, not the total.
 #
-# A consumer holds a `NetworkParameters`, so a sweep of bare sets alone reports the cheap column and
-# calls it the cost. It reported exactly that until this shape was added, and issue #16 read the
-# difference between the two columns as a cost of *nesting*, which it is not — a flat 369-leaf set and
-# a 16 × 24 one cost the same 13.8 s wrapped and the same 1.35 s bare.
+# That is how this sweep found what 0.2.3 removed. The gap was not a cost of the wrapper, and issue #16
+# was right that it was not a cost of nesting either: it was `LeafLayout`'s `prototype` type parameter,
+# which put every leaf's concrete array type into the layout type this method's caller infers through.
+# The two columns now agree — 1.05 s wrapped against 1.04 s bare at 369, 3.01 s against 3.07 s at 768,
+# 0.84 s against 0.85 s on a 16 × 24 set of the same 384 leaves — and the whole 369-wrapped path is
+# 8.64 s. The rows past 369 and the nested one are `scripts/leaf_layout_cost.jl`.
+# Both shapes are still swept, for two reasons: a consumer holds a `NetworkParameters`, so a sweep of
+# bare sets alone would report a shape nobody has, and two columns that agree are how the asymmetry
+# coming back would be noticed.
 #
 # The two shapes run in separate processes for the reason the widths do. They are different methods but
 # they share the inner `_layout(::NamedTuple, ::Int)` specialisation, so a bare row run first leaves the
-# wrapped row less to compile. On Julia 1.11 the wrapped 369 row takes about 25 s on its own account;
-# on 1.13 it takes about 5 s.
+# wrapped row less to compile. On Julia 1.11 the wrapped 369 row now takes about 10 s on its own
+# account, where before 0.2.3 it took about 25 s.
 
 using NeuralNetworkParameters
 

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -16,18 +16,19 @@ whose numbers are copied directly.
 abstract type ParameterLayout end
 
 """
-    LeafLayout(range, size, prototype)
+    LeafLayout(range, size)
 
 A leaf whose numbers are copied straight into the flat vector: it occupies `range`, and comes back
 `reshape`d to `size` (`()` for a scalar).
 
-`prototype` is the leaf it was built from, kept so that [`rebuild`](@ref) has something to rebuild
-against.
+This is the terminal case — [`freeparameters`](@ref) hands the leaf back unchanged — so there is
+nothing to rebuild and the layout is the shape alone. Two leaves of the same shape therefore share one
+layout type whatever they hold, and a stored layout keeps no reference to the parameters it was built
+from. [`WrappedLayout`](@ref) is the other case, and it does keep a prototype.
 """
-struct LeafLayout{N, P} <: ParameterLayout
+struct LeafLayout{N} <: ParameterLayout
     range::UnitRange{Int}
     size::NTuple{N, Int}
-    prototype::P
 end
 
 """
@@ -122,33 +123,37 @@ layout = parameterlayout(ps)
 """
 parameterlayout(ps) = first(_layout(ps, 0))
 
-# The container case, and **the one composition here that is deliberately left standing.**
+# The container case: the child walk, and then a step that wraps what it returns.
 #
-# This is the shape the note below calls the expensive way round: a `@generated` body yielding a large
-# type, composed across a function call with a step that wraps it. It costs what that shape costs. On
-# Julia 1.11, `parameterlayout` on a flat 369-leaf set is 1.37 s as a bare `NamedTuple` and **13.44 s**
-# inside a `NetworkParameters`; at 768 leaves, 2.73 s against 88.69 s. Nesting has nothing to do with
-# it, and the arithmetic of a `NestedLayout` being a larger type than a `LeafLayout` has nothing to do
-# with it either: a 16 × 24 set of the same 384 leaves costs 1.35 s bare and 13.84 s wrapped, exactly
-# as the flat one does.
+# Until 0.2.3 this was the expensive shape on Julia 1.11, and the cost was read as a cost of the
+# composition itself — a `@generated` body yielding a large type, composed across a function call with
+# a step that wraps it. It was not. `parameterlayout` on a flat 369-leaf set cost 1.35 s as a bare
+# `NamedTuple` and **13.40 s** inside a `NetworkParameters`; at 768 leaves, 2.77 s against **87.77 s**.
+# The cause was [`LeafLayout`](@ref)'s `prototype` type parameter, which put each leaf's concrete array
+# type into the layout type of every branch above it — 1849 nodes in the type tree of a 369-leaf
+# wrapped layout, against 742 without it. This method is where a caller paid for that, because it
+# infers through the child walk's whole return type to reach `ParametersLayout(inner)`, and inference
+# on such a type grows faster than the type does: 2.5 times the type was 13 times the time.
 #
-# Fusing it — one `@generated` body reading the children of `params(ps)` at literal indices and
-# building the `ParametersLayout` around them — is measured and is not what is wanted, because it
-# **moves** the cost rather than removing it. It takes `parameterlayout` from 13.59 s to 1.38 s at 369
-# wrapped and from 89.23 s to 2.81 s at 768, and puts every second of that into `flatten`: the whole
-# path — `parameterlayout`, then `flatten`, then `unflatten` — goes 22.41 s to 20.37 s, and a consumer
-# that calls only `flatten` and `unflatten` pays **twice as much**, 9.73 s against 20.73 s. The total
-# is what a consumer compiles, and the total does not depend on which method holds it: 21.66 s for the
-# bare 369 set and 22.41 s for the wrapped one.
+# With the parameter gone the two shapes cost the same — 1.05 s wrapped against 1.04 s bare at 369,
+# 3.01 s against 3.07 s at 768, 0.84 s against 0.85 s on a 16 × 24 set of the same 384 leaves — and so
+# do the three supported Julia versions: 1.05 s on 1.11, 1.13 s on 1.12, 1.03 s on 1.13, at 369 wrapped,
+# where the compat floor used to be the one that behaved differently. Nesting was never the driver and
+# is not one now, at 384 leaves in 16 branches against 369 in one.
 #
-# `@inline` here does nothing (13.67 s against 13.59 s), as `@noinline` does nothing on the branch
-# cases below. Nor is there anything to move on Julia 1.12 and 1.13, which do not distinguish the two
-# shapes: 1.78 s and 1.67 s at 369 wrapped. This is a characteristic of the compat floor and not of
-# the walk.
+# So there is nothing left here to move, and fusing the two steps into one `@generated` body — which
+# earlier releases measured, and declined — answers a question that no longer arises.
 #
-# A caller that wants only the size should call `flatlength`, which returns an `Int` — nothing
-# downstream of it depends on the layout type, and it costs 1.26 s here where `parameterlayout` costs
-# 13.20 s.
+# What survives is where to look rather than what to change. **The total is what a consumer compiles,
+# and it does not depend on which method holds it.** On 0.2.2 the bare and wrapped paths split their
+# cost completely differently and still summed to nearly the same figure: 1.35 + 14.38 + 4.23 s bare
+# against 13.50 + 4.14 + 4.26 s wrapped, over `parameterlayout`, `flatten` and `unflatten`. Moving a
+# second out of one entry point puts it into another; taking the type parameter out took the whole
+# 369-wrapped path from 21.90 s to **8.64 s**.
+#
+# The six shape-against-shape figures are `scripts/leaf_layout_cost.jl` and the three-column splits are
+# `scripts/wide_branch_cost.jl`, one process per row in both. The two agree on the 369-wrapped row they
+# share to within a tenth of a second, 13.40 s against 13.50 s, which is the spread to read the rest at.
 function _layout(ps::NetworkParameters, offset::Int)
     inner, off = _layout(params(ps), offset)
     ParametersLayout(inner), off
@@ -162,11 +167,12 @@ end
 # wrapping a tuple you already hold in a `NamedTuple` and a struct — 0.13 s. Composing them across a
 # function call is neither: inference has to carry the whole 369-element tuple type from the callee
 # into the caller's own inference, and `parameterlayout` on that set cost **11.7 s**, of which
-# the child walk alone was 0.49 s of it and the wrapping was the rest. Fused into one body, and with
-# the leaf union below removed, it is **1.36 s**.
+# the child walk alone was 0.49 s of it and the wrapping was the rest. Fused into one body, with the
+# leaf union below removed and (since 0.2.3) the leaf's array type out of its layout type, it is
+# **1.04 s**.
 #
-# The container case above is that same composition, left standing on purpose. Fusing it is measured
-# too, and the note there says why it is the one place where fusing does not pay.
+# The container case above is that same composition, and it is left standing. The note there says why:
+# what made it expensive was not the composition.
 #
 # Measured every way round before settling on this. A `@noinline` barrier on the child walk does not
 # help (11.78 s). Neither does supplying `NestedLayout`'s type parameters instead of letting them be
@@ -242,7 +248,7 @@ end
 
 @inline function _leaf_layout(x, offset::Int)
     n = length(x)
-    LeafLayout((offset + 1):(offset + n), _leafsize(x), x), offset + n
+    LeafLayout((offset + 1):(offset + n), _leafsize(x)), offset + n
 end
 
 @inline function _wrapped_layout(x, s, offset::Int)
@@ -261,11 +267,13 @@ The number of entries `ps` flattens to, without allocating the flat vector.
 Deliberately not called `parameterlength`: `AbstractNeuralNetworks` has a function of that name for
 the parameter count of a *model*, and the two would collide on `using`.
 
-Cheaper to compile than the layout it walks, and on a large set the difference is the whole cost: this
-returns an `Int`, so nothing downstream of the call depends on the layout's type. On Julia 1.11 a
-369-leaf `NetworkParameters` costs **1.26 s** here against 13.20 s through [`parameterlayout`](@ref),
-and the figure does not move with the width or the nesting. Anything that wants only the size should
-call this; anything that has to unflatten later needs the layout and cannot.
+This returns an `Int`, so nothing downstream of the call depends on the layout's type. Anything that
+wants only the size should call it; anything that has to unflatten later needs the layout and cannot.
+
+That used to be a large difference in compile time as well — on Julia 1.11, 1.26 s here against 13.20 s
+through [`parameterlayout`](@ref) on a 369-leaf `NetworkParameters`. It is not one any more: 0.2.3 took
+that set to 1.05 s through `parameterlayout` against 1.03 s here. The reason to prefer this is the type
+it hands back, not the clock.
 """
 flatlength(ps) = length(parameterlayout(ps))
 flatlength(l::ParameterLayout) = length(l)

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -21,10 +21,11 @@ abstract type ParameterLayout end
 A leaf whose numbers are copied straight into the flat vector: it occupies `range`, and comes back
 `reshape`d to `size` (`()` for a scalar).
 
-This is the terminal case — [`freeparameters`](@ref) hands the leaf back unchanged — so there is
-nothing to rebuild and the layout is the shape alone. Two leaves of the same shape therefore share one
-layout type whatever they hold, and a stored layout keeps no reference to the parameters it was built
-from. [`WrappedLayout`](@ref) is the other case, and it does keep a prototype.
+This is the terminal case — [`freeparameters`](@ref) hands back something of the leaf's own type —
+so there is nothing to rebuild and the layout is the shape alone. Two leaves of the same shape
+therefore share one layout type whatever they hold, and a stored layout keeps no reference to the
+parameters it was built from. [`WrappedLayout`](@ref) is the other case, and it does keep a
+prototype.
 """
 struct LeafLayout{N} <: ParameterLayout
     range::UnitRange{Int}
@@ -142,7 +143,7 @@ parameterlayout(ps) = first(_layout(ps, 0))
 # is not one now, at 384 leaves in 16 branches against 369 in one.
 #
 # So there is nothing left here to move, and fusing the two steps into one `@generated` body — which
-# earlier releases measured, and declined — answers a question that no longer arises.
+# the note this replaces measured, and declined — answers a question that no longer arises.
 #
 # What survives is where to look rather than what to change. **The total is what a consumer compiles,
 # and it does not depend on which method holds it.** On 0.2.2 the bare and wrapped paths split their

--- a/test/layout_tests.jl
+++ b/test/layout_tests.jl
@@ -39,6 +39,15 @@ end
     @test layout.inner.children.L1.children.b.size == (1,)
 end
 
+@testset "a leaf layout is the shape, not the leaf" begin
+    @test fieldnames(LeafLayout) == (:range, :size)
+    # leaves that differ only in what they hold share one layout type
+    w64 = parameterlayout(NetworkParameters((W = [1.0 2.0],))).inner.children.W
+    w32 = parameterlayout(NetworkParameters((W = Float32[1.0 2.0],))).inner.children.W
+    @test typeof(w64) === typeof(w32)
+    @test w64 == w32
+end
+
 @testset "scalar and empty leaves" begin
     l = parameterlayout(NetworkParameters((a = 1.5, b = Float64[], c = [2.0 3.0])))
     @test length(l) == 3

--- a/test/layout_tests.jl
+++ b/test/layout_tests.jl
@@ -46,6 +46,22 @@ end
     w32 = parameterlayout(NetworkParameters((W = Float32[1.0 2.0],))).inner.children.W
     @test typeof(w64) === typeof(w32)
     @test w64 == w32
+
+    # A terminal leaf's layout holds no reference to the leaf, so storing one does not keep the
+    # parameters alive. The three assertions here fail to three different things and none subsumes
+    # another: `fieldnames` above catches a field put back, `typeof` catches a type parameter put back,
+    # and this catches the *retention* — which is the property a consumer has, and which any field
+    # reaching the leaf by another route would break while the other two still passed. Eight megabytes
+    # against thirty-two bytes of leaf, so it cannot pass by the arrays happening to be small.
+    small = Base.summarysize(parameterlayout(NetworkParameters((W = zeros(2, 2),))))
+    large = Base.summarysize(parameterlayout(NetworkParameters((W = zeros(1000, 1000),))))
+    @test small == large
+
+    # The other case, stated so that the guarantee above is not read wider than it is: unflattening a
+    # structured leaf rebuilds against a prototype, so a `WrappedLayout` does hold its leaf.
+    l = parameterlayout(ps).inner.children.L2.children.S
+    @test l isa WrappedLayout
+    @test l.prototype === ps.L2.S
 end
 
 @testset "scalar and empty leaves" begin


### PR DESCRIPTION
Closes #15.

`LeafLayout` carried a `prototype` field that nothing read. A `LeafLayout` is by construction the case where `freeparameters(x) === x`, so `rebuild` on it is the identity and is never called — the two prototypes the package does read are both on `WrappedLayout`. The struct is now `LeafLayout{N}` over `range` and `size`, which is what all eleven methods dispatching on it already read and what `==` already compared.

## The issue's premise was wrong, and it matters

#15 filed this as hygiene and said explicitly that it was not the cause of the nested-layout compile cost. It is the cause. The issue's evidence — alternating `Matrix`/`Vector` leaves at 11.32 s against 13.9 s homogeneous — is sound, and its conclusion that leaf *diversity* is not the driver still holds. But it compared two sets under the old layout type and never compared the layout type with and without the parameter.

Toggling only the field, in one worktree, on Julia 1.11, one process per row (`scripts/leaf_layout_cost.jl`):

| `parameterlayout` on | 0.2.2 | 0.2.3 | type nodes |
|---|---|---|---|
| 369 leaves, bare `NamedTuple` | 1.35 s | 1.04 s | 1848 → 741 |
| 369 leaves, in a `NetworkParameters` | 13.40 s | **1.05 s** | 1849 → 742 |
| 768 leaves, bare | 2.77 s | 3.07 s | 3843 → 1539 |
| 768 leaves, in a `NetworkParameters` | 87.77 s | **3.01 s** | 3844 → 1540 |
| 16 × 24 nested, bare | 1.46 s | 0.85 s | 1971 → 819 |
| 16 × 24 nested, in a `NetworkParameters` | 14.00 s | **0.84 s** | 1972 → 820 |

**The bare column is what makes that the reading, and it does not improve** — at 768 it is a shade slower, 2.77 s against 3.07 s (2.76 against 2.99 on a second run, which is the spread of a single cold measurement). The type shrinks by 2.5× in that column too and buys nothing there. What was expensive was never the walk; it was what a caller had to infer through to wrap the walk's result, and only the wrapped column has such a caller.

`flatten` improves with it, 14.38 s to 3.61 s on the bare 369 set, and the whole path — `parameterlayout`, `flatten`, `unflatten` — goes 21.90 s to 8.64 s on the wrapped one. Julia 1.11, 1.12 and 1.13 now agree at 1.05 s, 1.13 s and 1.03 s; the compat floor used to be the version that behaved differently.

This also answers what #16 was about. The gap between the bare and wrapped columns was neither a cost of the wrapper nor a cost of nesting.

## What that costs in prose

Three blocks argued about figures this invalidates, so they are rewritten rather than renumbered:

- The note on `_layout(::NetworkParameters, ::Int)` called that method "the one composition here that is deliberately left standing" and argued at length that fusing it would only *move* the cost. Its premise — that the wrapped entry point is the expensive one — has gone, so the note now records what the asymmetry actually was. It was written after the 0.2.2 bump and has never shipped, so this is its first release either way.
- The `flatlength` docstring's "1.26 s here against 13.20 s through `parameterlayout`" is now 1.03 against 1.05. The reason to prefer `flatlength` is the `Int` it returns, not the clock.
- `scripts/wide_branch_cost.jl`'s header quoted the old figures throughout, and its two-shape sweep is now a regression guard rather than a discovery — two columns that agree are how the asymmetry coming back would be noticed.

`scripts/leaf_layout_cost.jl` is new because the 768 and 16 × 24 rows the prose quotes were not reproducible from the committed harness, and this repo's rule is that a number is reproducible only where the code that produced it is. It also measures type-tree nodes, and documents why `length(string(T))` cannot be used for that: Julia elides long types when printing, so a 369-child layout prints at about seven characters per child either way. I tried that measurement first and discarded it.

## Compatibility

Patch, not minor: the layouts are not exported and are built by `parameterlayout` rather than by hand. A caller who did construct one directly drops the third argument. Nothing in `AbstractNeuralNetworks`, `SymbolicNeuralNetworks`, `GeometricOptimizers` or `GeometricMachineLearning` constructs one or names the type parameters — `SymbolicNeuralNetworks` dispatches on the bare type and reads `layout.size` (`src/codegen/equation_sets.jl:222,225`), which is unaffected.

A layout also no longer holds a live reference to each leaf array, so keeping one no longer keeps the parameter set it was built from alive: `summarysize` of a one-leaf layout is 48 bytes whether the leaf is 2×2 or 1000×1000.

## Verification

- Full suite on Julia 1.11 and 1.13, before and after the prose changes. All 24 rows of `wide_branch_cost.jl` still read zero allocations — 0.2.1's guarantees are the reason that was checked rather than assumed.
- `docs/make.jl` on 1.11: doctests, cross-references and document checks clean. (It cannot run on 1.13 here for an unrelated reason — `docs/Manifest.toml` is pinned to the 1.11 stdlib set and 1.13 no longer ships `MbedTLS_jll`.)
- `SymbolicNeuralNetworks`' `test/codegen/equation_sets.jl` green against this tree in a scratch environment, that being the one place outside this package dispatching on `LeafLayout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)