### PR TITLE
Fix six defects an audit turned up, share three walk bodies, release 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ up is below.
   sub-network is the shape a consumer meets it in. The hole now passes straight out, which is what
   Zygote gives for the unwrapped parameters. A set that *was* touched is unchanged, holes and all.
 
+- **A layer called `params` had its gradient unwrapped a level too far.** The reverse pass runs
+  against `NamedTuple{keys(ps)}`, so what it hands back is keyed by the *layers* — and for a set of
+  one layer named `params` that tangent is shaped exactly like the structural one a tangent for the
+  wrapper would be. `ZygoteRulesExt` told the two apart by shape, so it unwrapped the real layer and
+  gave `NetworkParameters((params = [1.0, 1.0],))` where the gradient is
+  `NetworkParameters((params = (W = [1.0, 1.0],),))`: the layer's own shape lost, silently, with
+  nothing raised to say so. A layer may be called `params` — `getproperty` reaches into the wrapped
+  `NamedTuple`, so the field itself is read with `params(ps)` and the name is free — so the set's own
+  keys are asked about first now, and a tangent that is neither those keys nor a hole is named in an
+  `ArgumentError` instead of being spread over `keys(ps)`.
+
 - **A branch with no parameters could not be written to HDF5.** `_save_keyed` built its key attribute
   with `[String(k) for k in keys(nt)]`, whose element type over an empty branch is solved as
   `Union{}` — and HDF5 refuses a `Vector{Union{}}` attribute with a `TypeError` naming neither the
@@ -53,12 +64,33 @@ up is below.
 
 ### Changed
 
-- **`_storage_field` is written out**, for the reason `_accumulate_named!` above it is: a `for` over
-  `fieldnames(typeof(prototype))` indexes the struct at a *runtime* `Symbol`, so `getfield` comes back
-  as the union of the type's field types and the comparison is dispatched dynamically once per field.
-  Measured on a leaf whose storage is one of two fields, reverse pass warmed, fresh process per
-  reading, Julia 1.13.0-rc3 on an Apple M4 Max: **176 B a call as a loop, 144 B written out.** Pinned
-  as a bound, since the figure is the whole pullback's and not this walk's.
+- **Finding a structured leaf's storage no longer costs a leaf its fields.** `_storage_from_backing`
+  asks which of the prototype's fields `freeparameters` handed back and reads the cotangent's
+  component for it. Asked with a `for` over `fieldnames(typeof(prototype))`, that indexes the struct
+  at a *runtime* `Symbol`: `getfield` comes back as the union of the type's field types and the
+  comparison is dispatched dynamically once per field, so the reverse pass paid for every field the
+  leaf carried and not only for the one holding its numbers. Handing back the field's *name* does not
+  stop it either, since the name is then a runtime `Symbol` and `_cotangent_get`'s `haskey` a runtime
+  question — the point `_matching_named` makes about keys. `_storage_component` splices the whole
+  selection, which keeps both constant on every arm.
+
+  `@allocated` on the pullback with the call warmed, one process per reading, Julia 1.13.0-rc3 on an
+  Apple M4 Max, for the same three numbers of storage behind one field of metadata and behind five:
+
+  | | storage 1 of 2 fields | storage 6 of 6 |
+  |---|---|---|
+  | a `for` over the field names | 160 B | 512 B |
+  | the name spliced in | 128 B | 128 B |
+  | the selection spliced in | **96 B** | **96 B** |
+
+  The second column is what was wrong: the cost was the *number of fields*. So
+  `test/derivative_tests.jl` asserts the two columns are equal rather than pinning either — the figure
+  is the whole pullback's and not this walk's, and `@allocated` jitters on Windows.
+
+- **`similar(fp, S, dims)` builds its result with the `dims` it was given.** The two spellings agree
+  for the `Vector` a flat parameter set is built on, since `dims` is only kept when it equals
+  `size(parent(fp))`; the three-argument one is the one those dimensions were checked against, and it
+  is 1-based to match the ranges the layout hands out.
 
 - **The three branch cases of `unflatten` are written once**, over `AbstractVecOrMat` rather than once
   for a vector and again for a Jacobian. They recurse and put the children back in the shape of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,91 @@ Notable changes to `NeuralNetworkParameters` are recorded here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The package follows
 [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.6] — 2026-08-27
+## [0.2.5] — 2026-08-27
 
-An audit of the package for correctness, type piracy, type instability and avoidable allocations.
-Three of those four come back clean and stay that way: there is no piracy, every method here naming a
-type the package owns; the eight in-place walks still measure 0 B at 32, 48 and 369 children at both
-arities; and inference is concrete everywhere it is claimed to be, the `_map_zip` hand-off to
-`Base.map` past 32 children included, which is a compile-time trade and not a defect. What it turned
-up is below.
+Issue [#22] — a promotion that allocated on a wide branch — and the audit that followed it, for
+correctness, type piracy, type instability and avoidable allocations.
+
+Three of the audit's four questions come back clean, and the tests keep them that way: there is no
+piracy, every method here naming a type the package owns; the eight in-place walks measure 0 B at 32,
+48 and 369 children at both arities; and inference is concrete everywhere it is claimed to be, the
+`_map_zip` hand-off to `Base.map` past 32 children included, which is a compile-time trade and not a
+defect. What the two turned up is below.
 
 ### Fixed
+
+- **`parameter_eltype` took `values` of a branch, so it allocated on a wide one — and every walk here
+  reaches it.** `flatten(ps)` is `flatten(parameter_eltype(ps), ps)`, which is the documented spelling
+  for "the parameters' own element type", so the convenient form was the one that paid; and every
+  `NetworkParameters` runs its constructor through the promotion, so *building* a wide set paid it too.
+  The promotion now reads the branch in place with `getfield` at literal indices, as the other nine
+  across-children walks have since 0.2.2. Issue [#22], found in
+  `GeometricOptimizers` [#70](https://github.com/JuliaGNI/GeometricOptimizers.jl/issues/70), where
+  0.2.4's zipped `foldparameters` put `parameter_eltype` on a hot path for the first time.
+
+  `@allocated` from inside a function with the call warmed, `Float32` 2×2 leaves, Julia 1.13.0-rc3 on
+  an Apple M4 Max:
+
+  | branch | before | after |
+  |---|---|---|
+  | 32 children | 0 B | 0 B |
+  | 33 children | 544 B | **0 B** |
+  | 48 children | 800 B | **0 B** |
+  | 369 children | 6 144 B | **0 B** |
+  | `NetworkParameters` of the 369 | 6 144 B | **0 B** |
+  | `flatten(ps)` / `flatten(T, ps)`, 369 | 12 352 B / 6 208 B | **6 208 B / 6 208 B** |
+  | `rrule(flatten, ps)` / `rrule(flatten, T, ps)`, 369 | 12 352 B / 6 208 B | **6 208 B / 6 208 B** |
+
+  The reverse pass paid it on the same terms, because `rrule(flatten, ps)` derives the element type the
+  same way — so a gradient taken through the flat form of a wide bare set carried the 6 144 B as well.
+
+  **A branch of branches paid it as well, and the shape that shows it is not the one that looks worst.**
+  What decides the cost is the width of the *outer* branch, because `Base` unrolls a tuple up to 32
+  fields and drops to its `Any32` fallback past it. So a 16 × 24 set was already free while a 48 × 2
+  one — a child per layer, which is the shape a network of many layers has — cost 3 168 B and a
+  369 × 2 one 23 840 B. All are 0 B now.
+
+  These are D13 and D17's figures exactly, and this is their defect: `values(·)` on a branch
+  materialises a temporary tuple, which is free while the branch stays in registers and is not beyond
+  that. 0.2.2 removed it from the two forward walks and 0.2.3 from the three that take a second set.
+  This was the tenth, and it was the one none of that work measured — `scripts/wide_branch_cost.jl` had
+  no column for the element type until now, which is why the figure came from a consumer rather than
+  from here.
+
+  **The issue proposed a different fix, and it was not taken.** It read the cost as the runtime
+  `promote_type` chain the `@generated` body emits and proposed settling the element type in the type
+  domain instead. Measured, that chain is not the cost — `_promote_eltypes` handed a tuple *already
+  built* allocates 0 B at 369 children — and it is not a compile cost either: `parameter_eltype` on a
+  369-child branch takes 0.031 s cold with the fix against 0.036 s without. The shortcut would also
+  have changed an answer. Settling an `AbstractArray` child with `eltype` reads the interface a leaf
+  *presents*, where `parameter_eltype` follows `freeparameters` behind a `s === x` test and reports the
+  storage a leaf *has*; a leaf that is an `AbstractMatrix{Float64}` over a `Vector{Float32}` flattens
+  into a `Vector{Float32}` and would have flattened into a vector twice as wide. Nothing pinned that
+  case, as the issue noted; `test/leaves_tests.jl` pins it now, and the docstring states it as a
+  guarantee rather than leaving it to be read off the implementation.
+
+  What the fix buys downstream is the argument the issue makes for it. With the call free,
+  `GeometricOptimizers`' `_dot` is one widened signature rather than two — one taking the element type
+  off a `ParameterContainer{T}` to keep the wide flat shape free and one using `parameter_eltype` for
+  the nested shapes that bind no `T` — and `zero(parameter_eltype(x))` becomes usable in the folds
+  behind `l2norm` and `solution_scale`, which is the order-dependence in their accumulator that they
+  currently document instead.
+
+- **`test/wide_branch_tests.jl` asserts the element type in all four shapes** — bare, positional and
+  wrapped at both widths, and a branch of branches at 48, which is already well past the unrolling
+  boundary — together with the constructor that runs it, at exactly zero. `flatten(ps)` against
+  `flatten(T, ps)`, and the same pair on the reverse pass, are asserted as a *bound* rather than an
+  equality: `@allocated` reports the process-wide counter over its window and not the call's own, so
+  two readings of two multi-kilobyte calls differ by a few bytes on a loaded machine — Windows CI reads
+  6 039 against 6 055 for that pair. The bound is `8k`, half the per-child cost of a promotion taken
+  over `values`, which separates the jitter from the defect by two orders of magnitude at both widths.
+  Inference is asserted too: it was never what allocated, and a fix that lost the constant would be a
+  different regression.
+
+- **`scripts/wide_branch_cost.jl` sweeps the element type**, in the allocations column. Read the bare
+  column: the wrapped one is 0 by construction, since `parameter_eltype(::NetworkParameters{T})` is `T`
+  off the type, but its constructor promotes over the bare branch — so the bare figure is what building
+  the wrapped set costs. D22 is the same lesson one walk over.
 
 - **A gradient of a set the reverse pass never touched raised instead of returning `nothing`.**
   `ZygoteRulesExt` rewraps the pullback's `NamedTuple`, and when the reverse pass touched none of the
@@ -103,83 +178,6 @@ up is below.
   only that. The emitted code is unchanged, so the head of `layout.jl` still governs — the child walk
   and the wrapping still happen in one generated body, which is the thing that made it cheap. Being a
   helper a generator calls, it sits above both of them and `test/world_age_tests.jl` covers it.
-
-## [0.2.5] — 2026-08-26
-
-### Fixed
-
-- **`parameter_eltype` took `values` of a branch, so it allocated on a wide one — and every walk here
-  reaches it.** `flatten(ps)` is `flatten(parameter_eltype(ps), ps)`, which is the documented spelling
-  for "the parameters' own element type", so the convenient form was the one that paid; and every
-  `NetworkParameters` runs its constructor through the promotion, so *building* a wide set paid it too.
-  The promotion now reads the branch in place with `getfield` at literal indices, as the other nine
-  across-children walks have since 0.2.2. Issue [#22], found in
-  `GeometricOptimizers` [#70](https://github.com/JuliaGNI/GeometricOptimizers.jl/issues/70), where
-  0.2.4's zipped `foldparameters` put `parameter_eltype` on a hot path for the first time.
-
-  `@allocated` from inside a function with the call warmed, `Float32` 2×2 leaves, Julia 1.13.0-rc3 on
-  an Apple M4 Max:
-
-  | branch | before | after |
-  |---|---|---|
-  | 32 children | 0 B | 0 B |
-  | 33 children | 544 B | **0 B** |
-  | 48 children | 800 B | **0 B** |
-  | 369 children | 6 144 B | **0 B** |
-  | `NetworkParameters` of the 369 | 6 144 B | **0 B** |
-  | `flatten(ps)` / `flatten(T, ps)`, 369 | 12 352 B / 6 208 B | **6 208 B / 6 208 B** |
-  | `rrule(flatten, ps)` / `rrule(flatten, T, ps)`, 369 | 12 352 B / 6 208 B | **6 208 B / 6 208 B** |
-
-  The reverse pass paid it on the same terms, because `rrule(flatten, ps)` derives the element type the
-  same way — so a gradient taken through the flat form of a wide bare set carried the 6 144 B as well.
-
-  **A branch of branches paid it as well, and the shape that shows it is not the one that looks worst.**
-  What decides the cost is the width of the *outer* branch, because `Base` unrolls a tuple up to 32
-  fields and drops to its `Any32` fallback past it. So a 16 × 24 set was already free while a 48 × 2
-  one — a child per layer, which is the shape a network of many layers has — cost 3 168 B and a
-  369 × 2 one 23 840 B. All are 0 B now.
-
-  These are D13 and D17's figures exactly, and this is their defect: `values(·)` on a branch
-  materialises a temporary tuple, which is free while the branch stays in registers and is not beyond
-  that. 0.2.2 removed it from the two forward walks and 0.2.3 from the three that take a second set.
-  This was the tenth, and it was the one none of that work measured — `scripts/wide_branch_cost.jl` had
-  no column for the element type until now, which is why the figure came from a consumer rather than
-  from here.
-
-  **The issue proposed a different fix, and it was not taken.** It read the cost as the runtime
-  `promote_type` chain the `@generated` body emits and proposed settling the element type in the type
-  domain instead. Measured, that chain is not the cost — `_promote_eltypes` handed a tuple *already
-  built* allocates 0 B at 369 children — and it is not a compile cost either: `parameter_eltype` on a
-  369-child branch takes 0.031 s cold with the fix against 0.036 s without. The shortcut would also
-  have changed an answer. Settling an `AbstractArray` child with `eltype` reads the interface a leaf
-  *presents*, where `parameter_eltype` follows `freeparameters` behind a `s === x` test and reports the
-  storage a leaf *has*; a leaf that is an `AbstractMatrix{Float64}` over a `Vector{Float32}` flattens
-  into a `Vector{Float32}` and would have flattened into a vector twice as wide. Nothing pinned that
-  case, as the issue noted; `test/leaves_tests.jl` pins it now, and the docstring states it as a
-  guarantee rather than leaving it to be read off the implementation.
-
-  What the fix buys downstream is the argument the issue makes for it. With the call free,
-  `GeometricOptimizers`' `_dot` is one widened signature rather than two — one taking the element type
-  off a `ParameterContainer{T}` to keep the wide flat shape free and one using `parameter_eltype` for
-  the nested shapes that bind no `T` — and `zero(parameter_eltype(x))` becomes usable in the folds
-  behind `l2norm` and `solution_scale`, which is the order-dependence in their accumulator that they
-  currently document instead.
-
-- **`test/wide_branch_tests.jl` asserts the element type in all four shapes** — bare, positional and
-  wrapped at both widths, and a branch of branches at 48, which is already well past the unrolling
-  boundary — together with the constructor that runs it, at exactly zero. `flatten(ps)` against
-  `flatten(T, ps)`, and the same pair on the reverse pass, are asserted as a *bound* rather than an
-  equality: `@allocated` reports the process-wide counter over its window and not the call's own, so
-  two readings of two multi-kilobyte calls differ by a few bytes on a loaded machine — Windows CI reads
-  6 039 against 6 055 for that pair. The bound is `8k`, half the per-child cost of a promotion taken
-  over `values`, which separates the jitter from the defect by two orders of magnitude at both widths.
-  Inference is asserted too: it was never what allocated, and a fix that lost the constant would be a
-  different regression.
-
-- **`scripts/wide_branch_cost.jl` sweeps the element type**, in the allocations column. Read the bare
-  column: the wrapped one is 0 by construction, since `parameter_eltype(::NetworkParameters{T})` is `T`
-  off the type, but its constructor promotes over the bare branch — so the bare figure is what building
-  the wrapped set costs. D22 is the same lesson one walk over.
 
 ## [0.2.4] — 2026-08-26
 
@@ -840,7 +838,6 @@ The initial release: the `NetworkParameters` container and its flat `FlatParamet
 [#18]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/pull/18
 [#19]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/issues/19
 [#22]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/issues/22
-[0.2.6]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.2.6
 [0.2.5]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.2.5
 [0.2.4]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.2.4
 [0.2.3]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,74 @@ Notable changes to `NeuralNetworkParameters` are recorded here, following
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The package follows
 [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] — 2026-08-27
+
+An audit of the package for correctness, type piracy, type instability and avoidable allocations.
+Three of those four come back clean and stay that way: there is no piracy, every method here naming a
+type the package owns; the eight in-place walks still measure 0 B at 32, 48 and 369 children at both
+arities; and inference is concrete everywhere it is claimed to be, the `_map_zip` hand-off to
+`Base.map` past 32 children included, which is a compile-time trade and not a defect. What it turned
+up is below.
+
+### Fixed
+
+- **A gradient of a set the reverse pass never touched raised instead of returning `nothing`.**
+  `ZygoteRulesExt` rewraps the pullback's `NamedTuple`, and when the reverse pass touched none of the
+  parameters there is no `NamedTuple` to rewrap: one `nothing` stands for the whole set and cannot be
+  spread over `keys(ps)`. That case was unhandled, so it was a `MethodError: no method matching
+  _values(::Nothing)` — on the wrapper, where the bare `NamedTuple` it wraps returns `nothing` quite
+  happily. `Zygote.gradient(p -> 1.0, ps)` and a loss reading only the layout both failed; a frozen
+  sub-network is the shape a consumer meets it in. The hole now passes straight out, which is what
+  Zygote gives for the unwrapped parameters. A set that *was* touched is unchanged, holes and all.
+
+- **A branch with no parameters could not be written to HDF5.** `_save_keyed` built its key attribute
+  with `[String(k) for k in keys(nt)]`, whose element type over an empty branch is solved as
+  `Union{}` — and HDF5 refuses a `Vector{Union{}}` attribute with a `TypeError` naming neither the
+  branch nor the file. So `save` failed both for an empty set and for a set holding one parameter-free
+  layer, which is what an activation, a reshape or a dropout layer contributes. Everything else here
+  already carried an empty branch: `_layout` has an `n == 0` case per branch type, an empty set
+  flattens to an empty vector, and the roundtrip through `unflatten` is exact. Typing the
+  comprehension is the whole fix; `h5save(::Tuple)` escaped it only because `eachindex(())` is a
+  `Base.OneTo`, and is typed to match.
+
+- **`nothing` was not a structural zero for the `flatten` rules.** `_normalized` is explicit that it
+  is one, and `_flat_cotangent` took `AbstractZero` and `Tuple` but not `Nothing`, so the two
+  spellings of "no derivative" disagreed on the one path Zygote does not take — it converts a
+  `nothing` to a `ZeroTangent` before an `rrule` sees it, so a caller invoking the rule directly got a
+  `MethodError` where the other spelling got a zero.
+
+- **`fp[:L1]` inferred a `Union` where `fp.L1` inferred the layer.** The two spellings read a layer off
+  the flat form with the same body, and only `getproperty` was `@inline`d. Without it the literal is
+  not propagated into `_child_layout`, the child layout comes back as the union of every layer's, and
+  `unflatten` is dispatched dynamically. `ps[:L1]` and `ps.L1` on a `NetworkParameters` already agreed.
+
+- **A single-leaf set unflattened against its own flat form gave a reshaped `FlatParameters` for a
+  leaf.** `fp[l.range]` at full length goes through `similar`, which keeps the layout, so the leaf came
+  back as a reshaped parameter set rather than the ordinary array `unflatten` promises. Fixed at the
+  leaf, which is where the read happens and the one place a method is not ambiguous with the branch
+  cases. No aliasing was involved either way — indexing a range copies.
+
+### Changed
+
+- **`_storage_field` is written out**, for the reason `_accumulate_named!` above it is: a `for` over
+  `fieldnames(typeof(prototype))` indexes the struct at a *runtime* `Symbol`, so `getfield` comes back
+  as the union of the type's field types and the comparison is dispatched dynamically once per field.
+  Measured on a leaf whose storage is one of two fields, reverse pass warmed, fresh process per
+  reading, Julia 1.13.0-rc3 on an Apple M4 Max: **176 B a call as a loop, 144 B written out.** Pinned
+  as a bound, since the figure is the whole pullback's and not this walk's.
+
+- **The three branch cases of `unflatten` are written once**, over `AbstractVecOrMat` rather than once
+  for a vector and again for a Jacobian. They recurse and put the children back in the shape of the
+  branch, and neither step reads an entry; only the two leaf cases genuinely differ, a leaf taking its
+  own stretch of a vector and being rebuilt against the prototype, and taking the corresponding *rows*
+  of a Jacobian and not being.
+
+- **`_layout`'s two branch generators share the body they emit.** They differed only in the layout
+  wrapped round the children, so `_layout_body` builds the serial-offset body and each generator says
+  only that. The emitted code is unchanged, so the head of `layout.jl` still governs — the child walk
+  and the wrapping still happen in one generated body, which is the thing that made it cheap. Being a
+  helper a generator calls, it sits above both of them and `test/world_age_tests.jl` covers it.
+
 ## [0.2.5] — 2026-08-26
 
 ### Fixed
@@ -740,6 +808,7 @@ The initial release: the `NetworkParameters` container and its flat `FlatParamet
 [#18]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/pull/18
 [#19]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/issues/19
 [#22]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/issues/22
+[0.2.6]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.2.6
 [0.2.5]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.2.5
 [0.2.4]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.2.4
 [0.2.3]: https://github.com/JuliaGNI/NeuralNetworkParameters.jl/releases/tag/v0.2.3

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralNetworkParameters"
 uuid = "67f4d93a-60e9-472b-8cdd-1ccf6005724a"
-version = "0.2.6"
+version = "0.2.5"
 authors = ["Michael Kraus <michael.kraus@ipp.mpg.de> and contributors"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralNetworkParameters"
 uuid = "67f4d93a-60e9-472b-8cdd-1ccf6005724a"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Michael Kraus <michael.kraus@ipp.mpg.de> and contributors"]
 
 [deps]

--- a/ext/HDF5Ext.jl
+++ b/ext/HDF5Ext.jl
@@ -55,7 +55,7 @@ end
 function h5save(h5::HDF5.H5DataStore, t::Tuple, path::AbstractString)
     g = _group(h5, path)
     _set_attr!(g, KIND_ATTR, "Tuple")
-    _set_attr!(g, KEYS_ATTR, [string(i) for i in eachindex(t)])
+    _set_attr!(g, KEYS_ATTR, String[string(i) for i in eachindex(t)])
     for (i, v) in enumerate(t)
         h5save(g, v, string(i))
     end
@@ -72,8 +72,14 @@ function h5save(h5::HDF5.H5DataStore, x::Number, path::AbstractString)
     nothing
 end
 
+# `String[…]` and not `[…]`: over an empty branch the comprehension's element type is solved as
+# `Union{}`, and HDF5 cannot write a `Vector{Union{}}` attribute — it asks for an `AbstractArray`
+# convertible to `Cstring` and says so with a `TypeError` naming neither the branch nor the key. A
+# branch with no parameters is an ordinary thing for a network to have, since an activation, a reshape
+# or a dropout layer contributes one, and every other part of this package already carries it: `_layout`
+# has an `n == 0` case per branch type and an empty set flattens to an empty vector.
 function _save_keyed(g, nt::NamedTuple)
-    _set_attr!(g, KEYS_ATTR, [String(k) for k in keys(nt)])
+    _set_attr!(g, KEYS_ATTR, String[String(k) for k in keys(nt)])
     for (k, v) in pairs(nt)
         h5save(g, v, String(k))
     end

--- a/ext/ZygoteRulesExt.jl
+++ b/ext/ZygoteRulesExt.jl
@@ -18,21 +18,47 @@ function ZygoteRules.pullback(f::Function, ps::NetworkParameters)
     y, pb = ZygoteRules.pullback(f, NamedTuple{keys(ps)}(values(ps)))
 
     function network_parameters_pullback(output)
-        p̄ = _values(pb(output)[1])
-        (p̄ === nothing ? nothing : NetworkParameters(NamedTuple{keys(ps)}(p̄)),)
+        (_rewrap(ps, pb(output)[1]),)
     end
 
     y, network_parameters_pullback
 end
 
-_values(nt::NamedTuple) = values(nt)
-_values(nt::NamedTuple{(:params,), Tuple{AT}}) where {AT <: NamedTuple} = _values(nt.params)
+# The reverse pass ran against `NamedTuple{keys(ps)}`, so what it hands back is keyed by the set's own
+# layers already and goes into the wrapper as it stands.
+#
+# The set's keys are asked about *first*, and that ordering is the point rather than an accident. A set
+# whose one layer is called `params` is an ordinary set — `getproperty` reaches into the wrapped
+# `NamedTuple`, so the field itself is read with `params(ps)` and the name is free for a layer — and
+# its tangent is indistinguishable from the structural one below. Told apart by shape alone it was
+# unwrapped a level too far, and the gradient came back with that layer's own shape lost, silently and
+# without an error.
+#
+# Both questions are answered at compile time: the keys of a `NamedTuple` and of a `NetworkParameters`
+# are type parameters, so neither the comparison nor the `isa` survives into the reverse pass.
+function _rewrap(ps::NetworkParameters, p̄::NamedTuple)
+    keys(p̄) === keys(ps) && return NetworkParameters(p̄)
+    # A tangent built for the *struct* instead, whose one field is the wrapped `NamedTuple`: unwrap it
+    # and ask the same question of what is inside.
+    p̄ isa NamedTuple{(:params,)} && return _rewrap(ps, p̄.params)
+    _rewrap_error(ps, p̄)
+end
 
 # A reverse pass that touched none of the parameters hands back a structural zero for the whole set,
 # and there is nothing to rewrap: `keys(ps)` has as many entries as the set has layers and one
 # `nothing` cannot stand for each of them. So the hole is passed straight out, which is what Zygote
 # gives for the bare `NamedTuple` — a loss reading only the layout, or a frozen sub-network, would
 # otherwise raise where the unwrapped parameters return `nothing`.
-_values(::Nothing) = nothing
+_rewrap(::NetworkParameters, ::Nothing) = nothing
+
+_rewrap(ps::NetworkParameters, p̄) = _rewrap_error(ps, p̄)
+
+# Naming both shapes, where spreading the tangent over `keys(ps)` would raise about a length — or,
+# for a set of one layer, not raise at all.
+@noinline function _rewrap_error(ps, p̄)
+    throw(ArgumentError(string("the reverse pass returned a `", typeof(p̄),
+        "` for parameters keyed ", keys(ps),
+        "; expected a `NamedTuple` over those keys, or `nothing`")))
+end
 
 end

--- a/ext/ZygoteRulesExt.jl
+++ b/ext/ZygoteRulesExt.jl
@@ -18,8 +18,8 @@ function ZygoteRules.pullback(f::Function, ps::NetworkParameters)
     y, pb = ZygoteRules.pullback(f, NamedTuple{keys(ps)}(values(ps)))
 
     function network_parameters_pullback(output)
-        p̄ = pb(output)[1]
-        (NetworkParameters(NamedTuple{keys(ps)}(_values(p̄))),)
+        p̄ = _values(pb(output)[1])
+        (p̄ === nothing ? nothing : NetworkParameters(NamedTuple{keys(ps)}(p̄)),)
     end
 
     y, network_parameters_pullback
@@ -27,5 +27,12 @@ end
 
 _values(nt::NamedTuple) = values(nt)
 _values(nt::NamedTuple{(:params,), Tuple{AT}}) where {AT <: NamedTuple} = _values(nt.params)
+
+# A reverse pass that touched none of the parameters hands back a structural zero for the whole set,
+# and there is nothing to rewrap: `keys(ps)` has as many entries as the set has layers and one
+# `nothing` cannot stand for each of them. So the hole is passed straight out, which is what Zygote
+# gives for the bare `NamedTuple` — a loss reading only the layout, or a frozen sub-network, would
+# otherwise raise where the unwrapped parameters return `nothing`.
+_values(::Nothing) = nothing
 
 end

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -39,6 +39,12 @@ end
 
 # `flatten` returns a tuple, so its cotangent is a tangent *for the tuple*; only the first component,
 # the one for the flat vector, carries anything.
+#
+# `nothing` is a structural zero here as it is everywhere else in this file — the convention
+# `_normalized` states. Zygote converts one to a `ZeroTangent` before it reaches an `rrule`, so this
+# method is for a caller that invokes the rule directly; without it the two spellings of "no
+# derivative" disagree, and only the one Zygote does not use raises.
+_flat_cotangent(::Nothing) = nothing
 _flat_cotangent(Δ::ChainRulesCore.AbstractZero) = nothing
 _flat_cotangent(Δ::Tuple) = _normalized(first(Δ))
 _flat_cotangent(Δ::ChainRulesCore.Tangent) = _normalized(first(ChainRulesCore.backing(Δ)))
@@ -184,11 +190,18 @@ end
 
 _storage_from_backing(_, Δ) = Δ
 
-function _storage_field(prototype, storage)
-    for f in fieldnames(typeof(prototype))
-        getfield(prototype, f) === storage && return f
+# Written out for the reason `_accumulate_named!` above is, and this is the same walk's tail: a `for`
+# over `fieldnames(typeof(prototype))` indexes the struct at a *runtime* `Symbol`, so `getfield` comes
+# back as the union of the type's field types and the comparison is dispatched dynamically once per
+# field. Splicing the names in as literals keeps every one of them constant. Measured on a leaf whose
+# storage is one of two fields, reverse pass warmed, one process per reading: 176 B a call as a loop,
+# 144 B written out.
+@generated function _storage_field(prototype, storage)
+    expr = :nothing
+    for f in reverse(fieldnames(prototype))
+        expr = :(getfield(prototype, $(QuoteNode(f))) === storage ? $(QuoteNode(f)) : $expr)
     end
-    nothing
+    expr
 end
 
 # `freeparameters` of the prototype tells us which of the tangent's fields are the storage. Neither

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -184,22 +184,40 @@ function _storage_from_backing(prototype, nt::NamedTuple)
     # Single-block storage against a tangent over the struct's fields: `(S = ..., n = ZeroTangent())`
     # for a leaf whose storage is its `S`. Which field that is follows from the prototype — the object
     # `freeparameters` returned is one of its fields — so the cotangent is narrowed to that component.
-    f = _storage_field(prototype, s)
-    f === nothing ? nt : _cotangent_get(nt, f)
+    _storage_component(prototype, s, nt)
 end
 
 _storage_from_backing(_, Δ) = Δ
 
-# Written out for the reason `_accumulate_named!` above is, and this is the same walk's tail: a `for`
-# over `fieldnames(typeof(prototype))` indexes the struct at a *runtime* `Symbol`, so `getfield` comes
-# back as the union of the type's field types and the comparison is dispatched dynamically once per
-# field. Splicing the names in as literals keeps every one of them constant. Measured on a leaf whose
-# storage is one of two fields, reverse pass warmed, one process per reading: 176 B a call as a loop,
-# 144 B written out.
-@generated function _storage_field(prototype, storage)
-    expr = :nothing
+# Which field of the prototype the storage is, and the component of the cotangent that belongs to it,
+# decided in one generated body — written out for the reason `_accumulate_named!` above is, and this
+# is the same walk's tail.
+#
+# A `for` over `fieldnames(typeof(prototype))` indexes the struct at a *runtime* `Symbol`, so
+# `getfield` comes back as the union of the type's field types and the comparison is dispatched
+# dynamically once per field: the reverse pass pays for every field the leaf carries, and not only for
+# the one that holds its numbers. Handing back the field's *name* is not enough to stop that, because
+# the name is then a runtime `Symbol` in `_cotangent_get` and its `haskey` is a runtime question —
+# which is the point `_matching_named` below makes about keys. Splicing the whole selection keeps both
+# constant on every arm.
+#
+# `@allocated` on the pullback with the call warmed, one process per reading, Julia 1.13.0-rc3 on an
+# Apple M4 Max, for the same three numbers of storage behind one field of metadata and behind five:
+#
+# | | storage 1 of 2 fields | storage 6 of 6 |
+# |---|---|---|
+# | a `for` over the field names | 160 B | 512 B |
+# | the name spliced in | 128 B | 128 B |
+# | the selection spliced in | 96 B | 96 B |
+#
+# It is the second column that says what was wrong, not the first: what the loop cost was the number
+# of fields. `test/derivative_tests.jl` asserts the two columns are equal rather than pinning either,
+# since the figure is the whole pullback's and `@allocated` jitters on Windows.
+@generated function _storage_component(prototype, storage, nt)
+    expr = :nt
     for f in reverse(fieldnames(prototype))
-        expr = :(getfield(prototype, $(QuoteNode(f))) === storage ? $(QuoteNode(f)) : $expr)
+        expr = :(getfield(prototype, $(QuoteNode(f))) === storage ?
+                 _cotangent_get(nt, $(QuoteNode(f))) : $expr)
     end
     expr
 end

--- a/src/flat_parameters.jl
+++ b/src/flat_parameters.jl
@@ -81,7 +81,7 @@ end
 # same-length result; anything else is an ordinary array, since a layout that does not match its data
 # is worse than none.
 function Base.similar(fp::FlatParameters, ::Type{S}, dims::Dims) where {S}
-    dims == size(parent(fp)) ? FlatParameters(similar(parent(fp), S), flatlayout(fp)) :
+    dims == size(parent(fp)) ? FlatParameters(similar(parent(fp), S, dims), flatlayout(fp)) :
     similar(parent(fp), S, dims)
 end
 
@@ -97,7 +97,11 @@ end
 
 Base.propertynames(fp::FlatParameters) = (:data, :layout, _child_keys(flatlayout(fp))...)
 
-function Base.getindex(fp::FlatParameters, s::Symbol)
+# `@inline` for the reason `getproperty` above is: the two spellings read a layer off the same way and
+# have to infer the same way. Without it the literal `:L1` of `fp[:L1]` is not propagated into
+# `_child_layout`, the child layout comes back as the union of every layer's, and `unflatten` is
+# dispatched dynamically — where `fp.L1` infers the one concrete layer.
+@inline function Base.getindex(fp::FlatParameters, s::Symbol)
     unflatten(_child_layout(flatlayout(fp), s), parent(fp))
 end
 
@@ -142,6 +146,16 @@ end
 The structured form of `fp`, using the layout it carries.
 """
 unflatten(fp::FlatParameters) = unflatten(flatlayout(fp), parent(fp))
+
+# A leaf read *out of* a flat parameter set takes its numbers from the vector `fp` wraps. Left to the
+# generic path it would take `fp[l.range]`, and at full length — a set of one leaf — `similar` hands
+# that back as a `FlatParameters` still carrying the layout, so the leaf would come back as a reshaped
+# parameter set rather than the ordinary array `unflatten` promises.
+#
+# On the leaf and not on `ParameterLayout`: the branch cases only pass `data` down, so the leaf is
+# both where the read happens and the one place a method is not ambiguous with them — `ParameterLayout`
+# against `FlatParameters` is more specific in its second argument and less in its first.
+@inline unflatten(l::LeafLayout, fp::FlatParameters) = _reshape_leaf(parent(fp)[l.range], l.size)
 
 flatten!(fp::FlatParameters, ps) = (flatten!(parent(fp), ps, flatlayout(fp)); fp)
 unflatten!(ps, fp::FlatParameters) = unflatten!(ps, flatlayout(fp), parent(fp))

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -157,10 +157,17 @@ unflatten(layout, [10.0, 20.0, 30.0]).L1.W
 Each leaf is *copied* out of `v` rather than viewed into it, so the leaves are ordinary arrays and
 cannot alias each other or the flat vector.
 """
-@inline unflatten(l::ParametersLayout, v::AbstractVector) = NetworkParameters(unflatten(l.inner, v))
-@inline unflatten(l::NestedLayout, v::AbstractVector) =
-    NamedTuple{keys(l.children)}(_unflatten_children(l.children, v))
-@inline unflatten(l::TupleLayout, v::AbstractVector) = _unflatten_children(l.children, v)
+# The three branch cases are the same walk whether the flat form is a vector or a Jacobian — they
+# recurse and put the children back in the shape of the branch, and neither step reads an entry. So
+# they are written once over `AbstractVecOrMat`, and only the two leaf cases below are split: a leaf
+# takes its own stretch of a vector and is rebuilt, and takes the corresponding *rows* of a Jacobian
+# and is not.
+@inline unflatten(l::ParametersLayout, data::AbstractVecOrMat) = NetworkParameters(
+    unflatten(l.inner, data))
+@inline unflatten(l::NestedLayout, data::AbstractVecOrMat) =
+    NamedTuple{keys(l.children)}(_unflatten_children(l.children, data))
+@inline unflatten(l::TupleLayout, data::AbstractVecOrMat) = _unflatten_children(l.children, data)
+
 @inline unflatten(l::WrappedLayout, v::AbstractVector) = rebuild(l.prototype, unflatten(l.inner, v))
 @inline unflatten(l::LeafLayout, v::AbstractVector) = _reshape_leaf(v[l.range], l.size)
 
@@ -176,10 +183,6 @@ flat vector, so that the block belonging to each parameter can be read off.
 Each leaf becomes the ``n_\mathrm{leaf} \times \mathrm{size}(J, 2)`` row block it occupies. The leaves
 are *not* rebuilt: a block of a Jacobian is not a parameter, so there is nothing to rebuild it into.
 """
-@inline unflatten(l::ParametersLayout, J::AbstractMatrix) = NetworkParameters(unflatten(l.inner, J))
-@inline unflatten(l::NestedLayout, J::AbstractMatrix) =
-    NamedTuple{keys(l.children)}(_unflatten_children(l.children, J))
-@inline unflatten(l::TupleLayout, J::AbstractMatrix) = _unflatten_children(l.children, J)
 @inline unflatten(l::WrappedLayout, J::AbstractMatrix) = unflatten(l.inner, J)
 @inline unflatten(l::LeafLayout, J::AbstractMatrix) = J[l.range, :]
 

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -184,9 +184,20 @@ end
 #
 # The offset threads left to right, as the recursion this replaces did: the ranges a layout hands out
 # are the order `flatten` writes in.
-@generated function _layout(ps::NamedTuple{Keys}, offset::Int) where {Keys}
-    n = length(Keys)
-    n == 0 && return :((NestedLayout(NamedTuple{$Keys}(()), (offset + 1):offset), offset))
+# Both generators emit the same body and differ only in what is wrapped round the children, so the
+# body is built once here and each of them says only that. `wrap` receives the expression holding the
+# `k` children and the symbol holding the offset past the last of them, and returns the layout
+# expression. It runs in the generator, so the code that reaches the compiler is what it was when the
+# two bodies were written out in full — the head of this file's argument about fusing the child walk
+# and the wrapping into one generated body is untouched, since both still happen in one.
+#
+# The empty branch takes `offset` as its own final offset, which is what makes its range the empty
+# `(offset + 1):offset`.
+#
+# **A helper called from a generator, so it has to be defined above both of them** — see the note in
+# `walk.jl` on world age, which `test/world_age_tests.jl` pins.
+function _layout_body(n::Int, wrap)
+    n == 0 && return :(($(wrap(:(()), :offset)), offset))
     body = [:((child_1, off_1) = _layout(getfield(ps, 1), offset))]
     for i in 2:n
         push!(body, :(($(Symbol(:child_, i)), $(Symbol(:off_, i))) =
@@ -196,24 +207,17 @@ end
     final = Symbol(:off_, n)
     quote
         $(body...)
-        NestedLayout(NamedTuple{$Keys}($children), (offset + 1):$final), $final
+        $(wrap(children, final)), $final
     end
 end
 
+@generated function _layout(ps::NamedTuple{Keys}, offset::Int) where {Keys}
+    _layout_body(length(Keys),
+        (cs, final) -> :(NestedLayout(NamedTuple{$Keys}($cs), (offset + 1):$final)))
+end
+
 @generated function _layout(ps::Tuple, offset::Int)
-    n = fieldcount(ps)
-    n == 0 && return :((TupleLayout((), (offset + 1):offset), offset))
-    body = [:((child_1, off_1) = _layout(getfield(ps, 1), offset))]
-    for i in 2:n
-        push!(body, :(($(Symbol(:child_, i)), $(Symbol(:off_, i))) =
-            _layout(getfield(ps, $i), $(Symbol(:off_, i - 1)))))
-    end
-    children = Expr(:tuple, (Symbol(:child_, i) for i in 1:n)...)
-    final = Symbol(:off_, n)
-    quote
-        $(body...)
-        TupleLayout($children, (offset + 1):$final), $final
-    end
+    _layout_body(fieldcount(ps), (cs, final) -> :(TupleLayout($cs, (offset + 1):$final)))
 end
 
 # A leaf, terminal or wrapped, decided by **dispatch on the storage's type** rather than by an `if`

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -118,6 +118,21 @@ end
     @test Zygote.gradient(p -> sum(p.L1.W), ps)[1] isa NetworkParameters
 end
 
+@testset "a layer called `params` is a layer like any other" begin
+    # The reverse pass runs against `NamedTuple{keys(ps)}`, so its tangent is keyed by the layers —
+    # and a set of one layer named `params` has a tangent shaped exactly like the *structural* one a
+    # tangent for the wrapper would be. Told apart by shape rather than by the set's own keys, it was
+    # unwrapped a level too far and the layer's shape was lost, with nothing raised to say so.
+    qs = NetworkParameters((params = (W = [1.0, 2.0],),))
+    @test Zygote.gradient(p -> sum(p.params.W), qs)[1] ==
+          NetworkParameters((params = (W = [1.0, 1.0],),))
+    # and the structural shape still goes back in, for a set whose keys it cannot be
+    ext = Base.get_extension(NeuralNetworkParameters, :ZygoteRulesExt)
+    @test ext._rewrap(ps, (params = (L1 = (W = ones(2, 2), b = ones(2)),
+        L2 = (W = ones(1, 2), b = ones(1))),)) isa NetworkParameters
+    @test_throws ArgumentError ext._rewrap(ps, (nope = 1,))
+end
+
 @testset "`nothing` is a structural zero for the `flatten` rules too" begin
     # `_normalized` is explicit that `nothing` means "no derivative"; the `flatten` pullback took
     # `ZeroTangent` and not `nothing`, so the two spellings disagreed on the one path Zygote does not
@@ -161,26 +176,39 @@ _pullback_allocs(pb, Δ) = @allocated pb(Δ)
     @test _cost(layered) == _cost(flat)
 end
 
-@testset "the pullback does not pay to find a structured leaf's storage" begin
-    # `_storage_field` asks which of the prototype's fields `freeparameters` handed back, and used to
-    # ask it with a `for` over `fieldnames(typeof(prototype))`: `getfield` at a runtime `Symbol` comes
-    # back as the union of the type's field types, so the comparison was dispatched dynamically once
-    # per field. Written out, the names are literals and every one of them is constant. Measured on
-    # `Sym`, whose storage is one of two fields: 176 bytes a call as a loop, 144 written out.
-    #
-    # Bounded rather than equated, on both counts: the figure is the whole pullback's and not this
-    # walk's, and `@allocated` jitters on Windows.
-    sp = NetworkParameters((L1 = (W = sample_sym(), b = [1.0, 2.0]),))
+# One structured leaf beside a plain one, its cotangent given over the leaf's own fields: what the
+# pullback costs and what it reads.
+function _structured_leaf_pullback(leaf, Δleaf)
+    sp = NetworkParameters((L1 = (W = leaf, b = [1.0, 2.0]),))
     sv, sl = flatten(sp)
     _, spb = ChainRulesCore.rrule(unflatten, sl, sv)
     Δs = ChainRulesCore.Tangent{Any}(params = ChainRulesCore.Tangent{Any}(
-        L1 = ChainRulesCore.Tangent{Any}(
-            W = ChainRulesCore.Tangent{Any}(S = [1.0, 1.0, 1.0], n = ChainRulesCore.NoTangent()),
-            b = [1.0, 1.0])))
+        L1 = ChainRulesCore.Tangent{Any}(W = Δleaf, b = [1.0, 1.0])))
     _pullback_allocs(spb, Δs)                          # warm up the call and the measurement
-    @test _pullback_allocs(spb, Δs) ≤ 160
-    # and it still reads the right numbers into the right places
-    @test spb(Δs)[3] == ones(5)
+    _pullback_allocs(spb, Δs), spb(Δs)[3]
+end
+
+@testset "the pullback does not pay for the fields a structured leaf carries" begin
+    # `_storage_component` asks which of the prototype's fields `freeparameters` handed back and reads
+    # the cotangent's component for it, in one generated body. Asked with a `for` over
+    # `fieldnames(typeof(prototype))` instead, `getfield` at a runtime `Symbol` comes back as the union
+    # of the type's field types, so the comparison was dispatched dynamically once per field — and the
+    # reverse pass paid for every field the leaf carried rather than for the one holding its numbers.
+    #
+    # `Sym` keeps its three numbers in the first of two fields and `Padded` the same three in the last
+    # of six. They are compared with each other and not with a figure, for the reason the depth test
+    # above is: it is the *field count* that must not show up, and `@allocated` jitters on Windows. As
+    # a loop these cost 160 and 512 bytes on Julia 1.13; both now sit at 96.
+    cost_sym, read_sym = _structured_leaf_pullback(sample_sym(),
+        ChainRulesCore.Tangent{Any}(S = ones(3), n = ChainRulesCore.NoTangent()))
+    cost_padded, read_padded = _structured_leaf_pullback(sample_padded(),
+        ChainRulesCore.Tangent{Any}(a = ChainRulesCore.NoTangent(), b = ChainRulesCore.NoTangent(),
+            c = ChainRulesCore.NoTangent(), d = ChainRulesCore.NoTangent(),
+            e = ChainRulesCore.NoTangent(), S = ones(3)))
+    @test cost_padded == cost_sym
+    # and both still read the right numbers into the right places
+    @test read_sym == ones(5)
+    @test read_padded == ones(5)
 end
 
 @testset "a tuple branch reads a cotangent shorter than itself" begin

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -105,6 +105,29 @@ end
     @test g.a == [1.0, 1.0]
 end
 
+@testset "a set the reverse pass never touched comes back as `nothing`" begin
+    # The extension rewraps the pullback's `NamedTuple`, and when the reverse pass touched none of the
+    # parameters there is no `NamedTuple` to rewrap: one `nothing` stands for the whole set and cannot
+    # be spread over `keys(ps)`. It used to raise `MethodError: no method matching _values(::Nothing)`
+    # here, where the bare `NamedTuple` the set wraps returns `nothing` quite happily — so a loss that
+    # reads only the layout, or a frozen sub-network, failed on the wrapper and not on its contents.
+    @test Zygote.gradient(p -> 1.0, ps) === (nothing,)
+    @test Zygote.gradient(p -> Float64(length(flatten(p)[2])), ps) === (nothing,)
+    @test Zygote.gradient(p -> 1.0, params(ps)) === (nothing,)      # what it has to agree with
+    # a set that *was* touched still comes back wrapped, holes and all
+    @test Zygote.gradient(p -> sum(p.L1.W), ps)[1] isa NetworkParameters
+end
+
+@testset "`nothing` is a structural zero for the `flatten` rules too" begin
+    # `_normalized` is explicit that `nothing` means "no derivative"; the `flatten` pullback took
+    # `ZeroTangent` and not `nothing`, so the two spellings disagreed on the one path Zygote does not
+    # take — a caller invoking the rule directly got a `MethodError` instead of a zero.
+    (_, _), pb1 = ChainRulesCore.rrule(flatten, ps)
+    @test pb1(nothing) == (ChainRulesCore.NoTangent(), ChainRulesCore.ZeroTangent())
+    (_, _), pb2 = ChainRulesCore.rrule(flatten, Float64, ps)
+    @test pb2(nothing)[3] == ChainRulesCore.ZeroTangent()
+end
+
 @testset "a structural zero contributes nothing to the promotion" begin
     @test NeuralNetworkParameters.parameter_eltype(ChainRulesCore.ZeroTangent()) === Union{}
     @test NeuralNetworkParameters.parameter_eltype((a = [1.0f0], b = ChainRulesCore.ZeroTangent())) ===
@@ -136,6 +159,28 @@ _pullback_allocs(pb, Δ) = @allocated pb(Δ)
     flat = NetworkParameters((a = L, b = L, c = L, d = L))
     layered = NetworkParameters((L1 = (a = L,), L2 = (b = L,), L3 = (c = L,), L4 = (d = L,)))
     @test _cost(layered) == _cost(flat)
+end
+
+@testset "the pullback does not pay to find a structured leaf's storage" begin
+    # `_storage_field` asks which of the prototype's fields `freeparameters` handed back, and used to
+    # ask it with a `for` over `fieldnames(typeof(prototype))`: `getfield` at a runtime `Symbol` comes
+    # back as the union of the type's field types, so the comparison was dispatched dynamically once
+    # per field. Written out, the names are literals and every one of them is constant. Measured on
+    # `Sym`, whose storage is one of two fields: 176 bytes a call as a loop, 144 written out.
+    #
+    # Bounded rather than equated, on both counts: the figure is the whole pullback's and not this
+    # walk's, and `@allocated` jitters on Windows.
+    sp = NetworkParameters((L1 = (W = sample_sym(), b = [1.0, 2.0]),))
+    sv, sl = flatten(sp)
+    _, spb = ChainRulesCore.rrule(unflatten, sl, sv)
+    Δs = ChainRulesCore.Tangent{Any}(params = ChainRulesCore.Tangent{Any}(
+        L1 = ChainRulesCore.Tangent{Any}(
+            W = ChainRulesCore.Tangent{Any}(S = [1.0, 1.0, 1.0], n = ChainRulesCore.NoTangent()),
+            b = [1.0, 1.0])))
+    _pullback_allocs(spb, Δs)                          # warm up the call and the measurement
+    @test _pullback_allocs(spb, Δs) ≤ 160
+    # and it still reads the right numbers into the right places
+    @test spb(Δs)[3] == ones(5)
 end
 
 @testset "a tuple branch reads a cotangent shorter than itself" begin

--- a/test/flat_parameters_tests.jl
+++ b/test/flat_parameters_tests.jl
@@ -40,6 +40,30 @@ end
     @test :L1 in propertynames(fp)
 end
 
+@testset "both spellings of reading a layer infer the same" begin
+    # `getindex` and `getproperty` have the same body, and only `getproperty` was `@inline`d. Without
+    # it the literal `:L1` is not propagated into `_child_layout`, so the child layout comes back as
+    # the union of every layer's and `unflatten` is dispatched dynamically — `fp[:L1]` inferred a
+    # `Union` where `fp.L1` inferred the one concrete layer.
+    # Asked through a closure holding the literal and not with `@inferred`, which infers the call as
+    # `getindex(::FlatParameters, ::Symbol)` and so throws the constant away before the question is
+    # put — the property it has to pin is the one a written-out `fp[:L1]` gets.
+    @test fp[:L1] == fp.L1
+    @test isconcretetype(only(Base.return_types(p -> p[:L1], Tuple{typeof(fp)})))
+    @test isconcretetype(only(Base.return_types(p -> p.L1, Tuple{typeof(fp)})))
+end
+
+@testset "a layout unflattened against a flat set gives ordinary leaves" begin
+    # `fp[l.range]` at full length goes through `similar`, which keeps the layout, so a single-leaf
+    # set came back as a leaf reshaped from a `FlatParameters` rather than the plain array
+    # `unflatten` promises
+    one = NetworkParameters((L1 = (W = [1.0 2.0],),))
+    ofp = FlatParameters(one)
+    @test unflatten(flatlayout(ofp), ofp).L1.W isa Matrix{Float64}
+    @test unflatten(flatlayout(ofp), ofp) == one
+    @test unflatten(flatlayout(fp), fp) == ps
+end
+
 @testset "similar keeps the layout" begin
     @test flatlayout(similar(fp)) == flatlayout(fp)
     @test similar(fp) isa FlatParameters

--- a/test/hdf5_tests.jl
+++ b/test/hdf5_tests.jl
@@ -31,6 +31,22 @@ end
     @test back == ps
 end
 
+@testset "a branch with no parameters round trips" begin
+    # An activation, a reshape or a dropout layer contributes an empty branch, and every other part of
+    # this package carries one: `_layout` has an `n == 0` case per branch type and an empty set
+    # flattens to an empty vector. Writing one used to fail in the key attribute, where the
+    # comprehension over no keys is solved as `Vector{Union{}}` and HDF5 rejects it with a `TypeError`
+    # naming neither the branch nor the file.
+    for ps in (NetworkParameters(NamedTuple()),
+        NetworkParameters((L1 = NamedTuple(), L2 = (W = [1.0],))),
+        NetworkParameters((L1 = (W = [1.0], t = ()),)))
+        f = tmp()
+        @test save(f, ps) == f
+        @test load(NetworkParameters, f) == ps
+        @test load(NetworkParameters, f, ps) == ps      # and against a prototype
+    end
+end
+
 @testset "element type is preserved" begin
     f = tmp()
     save(f, NetworkParameters((a = Float32[1, 2],)))

--- a/test/world_age_tests.jl
+++ b/test/world_age_tests.jl
@@ -4,10 +4,10 @@
 # the *generator* body — as does, for a walk over more than one set, the chain of `_branch_keys`,
 # `_child_expr` and their two error helpers. `_layout`'s two branch cases reach `_layout_body`, which
 # builds the body both of them share, on the same terms. A generator runs in the world age of its own
-# method definition, so a helper defined further down the file is invisible to it and the generator raises
-# `MethodError: no method matching _children_arity(…)  The applicable method may be too new`. That is
-# a real defect and it was one: `_children_arity` used to sit at the foot of `src/walk.jl`, below
-# `_map_zip` and `_foreach_zip`.
+# method definition, so a helper defined further down the file is invisible to it and the generator
+# raises `MethodError: no method matching _children_arity(…)  The applicable method may be too new`.
+# That is a real defect and it was one: `_children_arity` used to sit at the foot of `src/walk.jl`,
+# below `_map_zip` and `_foreach_zip`.
 #
 # It cannot be caught in-process. Loading a precompiled package deserialises every method in the
 # module into one world age, which is exactly the condition that hides it — so the whole of the rest
@@ -62,13 +62,13 @@ end
 v, layout = flatten(ps)
 v == [1.0, 2.0, 3.0, 4.0] || exit(4)
 unflatten(layout, v) == ps || exit(5)
-
-# and `_layout_body`'s empty-branch arm, which is the one `wrap` call the walk above does not make
-flatten((L1 = NamedTuple(), L2 = (W = [1.0],), L3 = (t = (),)))[1] == [1.0] || exit(15)
 let qs = mapparameters(zero, ps)
     unflatten!(qs, layout, v)
     qs == ps || exit(6)
 end
+
+# and `_layout_body`'s empty-branch arm, which is the one `wrap` call the walk above does not make
+flatten((L1 = NamedTuple(), L2 = (W = [1.0],), L3 = (t = (),)))[1] == [1.0] || exit(15)
 
 # `_fold_zip` at arity one, and at the arity that reaches `_branch_keys` and `_child_expr` from the
 # fold's own generator; `foldstorage` is its other `_fold_step`

--- a/test/world_age_tests.jl
+++ b/test/world_age_tests.jl
@@ -2,8 +2,9 @@
 #
 # Every across-children walk is a `@generated` function, and four of them call `_children_arity` from
 # the *generator* body — as does, for a walk over more than one set, the chain of `_branch_keys`,
-# `_child_expr` and their two error helpers. A generator runs in the world age of its own method
-# definition, so a helper defined further down the file is invisible to it and the generator raises
+# `_child_expr` and their two error helpers. `_layout`'s two branch cases reach `_layout_body`, which
+# builds the body both of them share, on the same terms. A generator runs in the world age of its own
+# method definition, so a helper defined further down the file is invisible to it and the generator raises
 # `MethodError: no method matching _children_arity(…)  The applicable method may be too new`. That is
 # a real defect and it was one: `_children_arity` used to sit at the foot of `src/walk.jl`, below
 # `_map_zip` and `_foreach_zip`.
@@ -56,11 +57,14 @@ let n = Ref(0)
     n[] == 0 || exit(9)
 end
 
-# `_flatten_children!`, `_unflatten_children`, `_unflatten_children!`, `_layout`,
-# `_promote_eltypes`
+# `_flatten_children!`, `_unflatten_children`, `_unflatten_children!`, `_layout` and the
+# `_layout_body` its generators share, `_promote_eltypes`
 v, layout = flatten(ps)
 v == [1.0, 2.0, 3.0, 4.0] || exit(4)
 unflatten(layout, v) == ps || exit(5)
+
+# and `_layout_body`'s empty-branch arm, which is the one `wrap` call the walk above does not make
+flatten((L1 = NamedTuple(), L2 = (W = [1.0],), L3 = (t = (),)))[1] == [1.0] || exit(15)
 let qs = mapparameters(zero, ps)
     unflatten!(qs, layout, v)
     qs == ps || exit(6)

--- a/test/wrapper_types.jl
+++ b/test/wrapper_types.jl
@@ -39,6 +39,26 @@ NNP.freeparameters(g::TwoBlock) = (A = g.A, B = g.B)
 NNP.rebuild(g::TwoBlock, data) = TwoBlock(data.A, data.B, g.N)
 NNP.parameter_metadata(g::TwoBlock) = (N = g.N,)
 
+# `Padded` stands in for no downstream type. It keeps the same three numbers as `Sym` behind *five*
+# fields of metadata rather than one, and it is here so that the reverse pass can be asked whether
+# finding the storage among a leaf's fields costs anything per field — a question a single field count
+# cannot answer.
+struct Padded{T} <: AbstractVector{T}
+    a::Int
+    b::Int
+    c::Int
+    d::Int
+    e::Int
+    S::Vector{T}
+end
+
+Base.size(x::Padded) = size(x.S)
+Base.getindex(x::Padded, i::Int) = x.S[i]
+
+NNP.freeparameters(x::Padded) = x.S
+NNP.rebuild(x::Padded, data) = Padded(x.a, x.b, x.c, x.d, x.e, data)
+NNP.parameter_metadata(x::Padded) = (a = x.a, b = x.b, c = x.c, d = x.d, e = x.e)
+
 struct Manifold{T, AT <: AbstractMatrix{T}} <: AbstractMatrix{T}
     A::AT
 end
@@ -53,6 +73,9 @@ NNP.rebuild(::Manifold, data) = Manifold(data)
 "A three-number symmetric matrix and the five-number two-block lift built on it."
 sample_sym() = Sym([1.0, 2.0, 3.0], 2)
 sample_twoblock() = TwoBlock(Sym([4.0, 5.0, 6.0], 2), [7.0 8.0], 3)
+
+"The same three numbers as `sample_sym`, behind five fields of metadata rather than one."
+sample_padded() = Padded(1, 2, 3, 4, 5, [1.0, 2.0, 3.0])
 
 "A four-number matrix that is its own storage."
 sample_manifold() = Manifold([1.0 2.0; 3.0 4.0])


### PR DESCRIPTION
An audit of the package for correctness, type piracy, type instability and avoidable allocations.

**This goes out as 0.2.5, not 0.2.6.** The last release in General is v0.2.4; `main` has declared 0.2.5 since #23 and carries a CHANGELOG entry for it, but nothing ever tagged it. Registering 0.2.6 would ask the registry to skip a version, which AutoMerge's sequential-increment guideline does not take. So the two CHANGELOG entries are one: #22's promotion fix and the audit that followed it ship together as 0.2.5.

Three of the four questions come back clean, and the tests keep them that way:

- **No type piracy.** Every `Base.*`, `ChainRulesCore.*` and `ZygoteRules.*` method here names a type the package owns.
- **Allocations hold.** `flatten!`, `unflatten!`, `foreachparameters`, `mapparameters!`, `mapstorage!`, `parameter_eltype`, `foldparameters` and `foldstorage` all measure **0 B** at 32, 48 and 369 children, at arity one and two.
- **Inference holds where it is claimed to.** Including the `_map_zip` hand-off to `Base.map` past 32 children, which is concrete at 32 and a union at 33 exactly as `walk.jl` documents — a compile-time trade, not a defect.

## Fixed

- **A gradient of a set the reverse pass never touched raised instead of returning `nothing`.** `ZygoteRulesExt` rewraps the pullback's `NamedTuple`, and when the reverse pass touched none of the parameters there is none to rewrap: one `nothing` stands for the whole set and cannot be spread over `keys(ps)`. That case was unhandled, so it was a `MethodError: no method matching _values(::Nothing)` — on the wrapper, where the bare `NamedTuple` it wraps returns `nothing` quite happily.

  ```julia
  Zygote.gradient(p -> 1.0, ps)                             # raised
  Zygote.gradient(p -> Float64(length(flatten(p)[2])), ps)  # raised
  Zygote.gradient(p -> 1.0, params(ps))                     # (nothing,) — what it has to agree with
  ```

  A frozen sub-network is the shape a consumer meets this in. A set that *was* touched is unchanged, holes and all.

- **A layer called `params` had its gradient unwrapped a level too far.** The reverse pass runs against `NamedTuple{keys(ps)}`, so what it hands back is keyed by the *layers* — and for a set of one layer named `params` that tangent is shaped exactly like the structural one a tangent for the wrapper would be. Told apart by shape, the real layer was unwrapped:

  ```julia
  ps = NetworkParameters((params = (W = [1.0, 2.0],),))
  Zygote.gradient(p -> sum(p.params.W), ps)[1]
  # NetworkParameters((params = [1.0, 1.0],))           ← the layer's shape gone
  # NetworkParameters((params = (W = [1.0, 1.0],),))    ← what it is
  ```

  A layer may be called `params` — `getproperty` reaches into the wrapped `NamedTuple` and the field itself is read with `params(ps)`. Nothing raised, and the set that came back was a `NetworkParameters` of the right arity, so it survived every `isa` a consumer would put to it and failed later, somewhere else. The set's own keys are asked about first now, and a tangent that is neither those keys nor a hole is named in an `ArgumentError`.

- **A branch with no parameters could not be written to HDF5.** `_save_keyed` built its key attribute with `[String(k) for k in keys(nt)]`, whose element type over an empty branch is solved as `Union{}` — and HDF5 refuses a `Vector{Union{}}` attribute with a `TypeError` naming neither the branch nor the file. So `save` failed both for an empty set and for a set holding one parameter-free layer, which is what an activation, a reshape or a dropout layer contributes. Everything else already carried an empty branch: `_layout` has an `n == 0` case per branch type, and an empty set flattens to an empty vector.

- **`nothing` was not a structural zero for the `flatten` rules,** against the convention `_normalized` states one line above. Zygote converts a `nothing` to a `ZeroTangent` before an `rrule` sees it, so this was reachable only by invoking the rule directly — a consistency fix rather than a live failure.

- **`fp[:L1]` inferred a `Union` where `fp.L1` inferred the layer.** The two spellings read a layer off the flat form with the same body, and only `getproperty` was `@inline`d; without it the literal is not propagated into `_child_layout` and `unflatten` is dispatched dynamically. `ps[:L1]` and `ps.L1` on a `NetworkParameters` already agreed.

- **A single-leaf set unflattened against its own flat form gave a reshaped `FlatParameters` for a leaf,** since `fp[l.range]` at full length goes through `similar`, which keeps the layout. Fixed at the leaf, which is where the read happens and the one place a method is not ambiguous with the branch cases. No aliasing was involved either way — indexing a range copies.

## Changed

- **Finding a structured leaf's storage no longer costs a leaf its fields.** `_storage_from_backing` asks which of the prototype's fields `freeparameters` handed back and reads the cotangent's component for it. Asked with a `for` over `fieldnames(typeof(prototype))`, that indexes the struct at a *runtime* `Symbol`: `getfield` comes back as the union of the type's field types and the comparison is dispatched dynamically once per field, so the reverse pass paid for every field the leaf carried and not only for the one holding its numbers. Handing back the field's *name* does not stop it either — the name is then a runtime `Symbol` and `_cotangent_get`'s `haskey` a runtime question, the point `_matching_named` makes about keys. `_storage_component` splices the whole selection.

  `@allocated` on the pullback with the call warmed, one process per reading, Julia 1.13.0-rc3 on an Apple M4 Max, for the same three numbers of storage behind one field of metadata and behind five:

  | | storage 1 of 2 fields | storage 6 of 6 |
  |---|---|---|
  | a `for` over the field names | 160 B | 512 B |
  | the name spliced in | 128 B | 128 B |
  | the selection spliced in | **96 B** | **96 B** |

  The second column is what was wrong: the cost was the *number of fields*.

- **The three branch cases of `unflatten` are written once**, over `AbstractVecOrMat` rather than once for a vector and again for a Jacobian. Only the two leaf cases genuinely differ.

- **`_layout`'s two branch generators share the body they emit.** `_layout_body` builds the serial-offset body; the emitted code is unchanged, so the head of `layout.jl` still governs — the child walk and the wrapping still happen in one generated body.

- **`similar(fp, S, dims)` builds its result with the `dims` it was given.** The two spellings agree for the `Vector` a flat parameter set is built on, since `dims` is only kept when it equals `size(parent(fp))`; the three-argument one is the one those dimensions were checked against, and it is 1-based to match the ranges the layout hands out.

## Tests

536 pass, up from 509. Each fix is pinned where it is asserted: the two Zygote rewrap cases and the `rrule` structural zeros in `derivative_tests.jl`, the empty-branch roundtrip through both `load` forms in `hdf5_tests.jl`, the two accessors' inference and the single-leaf unflatten in `flat_parameters_tests.jl`, and `_layout_body`'s empty-branch arm in `world_age_tests.jl` — that last because it is a helper a generator calls, so it is subject to the world-age rule `walk.jl` documents.

The inference test asks through a closure holding the literal rather than with `@inferred`, which infers the call as `getindex(::FlatParameters, ::Symbol)` and so throws the constant away before the question is put.

The storage test compares two *shapes* rather than pinning a figure, for the reason the depth test above it does: `Sym` keeps its three numbers in the first of two fields and `Padded` the same three in the last of six, and it is the field count that must not show up. A bound would not have held — the loop reads exactly 160 B on this machine, so a `≤ 160` passed with the change reverted.

Docs build clean, doctests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
